### PR TITLE
fix: 条文番号表示バグを修正（suppl_/fusoku_/amendment_対応+ロジック集約）

### DIFF
--- a/docs/article-naming-convention.md
+++ b/docs/article-naming-convention.md
@@ -238,31 +238,16 @@ src/data/laws/
 **utils.ts** - 条文番号のフォーマット処理:
 
 ```typescript
-export function formatArticleNumber(article: string | number): string {
-  const articleStr = String(article);
-
-  // 附則
-  if (articleStr.startsWith('suppl-')) {
-    return `附則第${articleStr.replace('suppl-', '')}条`;
-  }
-
-  // 修正条項
-  if (articleStr.startsWith('amend-')) {
-    return `修正第${articleStr.replace('amend-', '')}条`;
-  }
-
-  // 枝番
-  if (articleStr.includes('-')) {
-    return `第${articleStr.replace('-', '条の')}条`;
-  }
-
-  // アルファ条文（ドイツ等）
-  if (/^\d+[a-z]$/.test(articleStr)) {
-    return `第${articleStr}条`;
-  }
-
-  // 通常条文
-  return `第${articleStr}条`;
+export function formatArticleNumber(article: number | string): string {
+  if (typeof article === 'number') return `第${article}条`;
+  const s = String(article);
+  // 附則（suppl / fusoku、ハイフン・アンダースコア両対応）
+  const supplMatch = s.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  if (supplMatch) return `附則第${supplMatch[1]}条`;
+  // 修正条項（amend / amendment、同上）
+  const amendMatch = s.match(/^(?:amend|amendment)[_-](.+)$/);
+  if (amendMatch) return `修正第${amendMatch[1]}条`;
+  return `第${article}条`;
 }
 ```
 

--- a/src/app/api/article-image/route.tsx
+++ b/src/app/api/article-image/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 import { getArticle, getLawMetadata } from '@/lib/db';
+import { formatArticleNumber } from '@/lib/utils';
 
 export const runtime = 'edge';
 
@@ -51,7 +52,7 @@ export async function GET(request: Request) {
   const displayCommentary = commentaryOsaka.map(stripHtml);
 
   const titleOsaka = articleRow.title_osaka || articleRow.title || '';
-  const articleLabel = `第${article}条`;
+  const articleLabel = formatArticleNumber(article);
 
   // Klee One フォントを Google Fonts から取得
   let fontData: ArrayBuffer;

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -61,8 +61,8 @@ function getFirstParagraph(originalTextJson: string | null | undefined): string 
 
 // 条文番号から基本番号を抽出（1-2 → 1, 876-5 → 876）
 function getBaseArticleNumber(article: string): number {
-  // suppl-1 や amend-1 は特別扱い
-  if (article.startsWith('suppl-') || article.startsWith('amend-')) {
+  // suppl-1 や amend-1 は特別扱い（アンダースコア / fusoku / amendment も対応）
+  if (/^(?:suppl|fusoku|amend|amendment)[_-]/.test(article)) {
     return -1; // 附則は別扱い
   }
   // 枝番（1-2など）は基本番号を返す
@@ -80,7 +80,7 @@ function classifyArticles(articles: ArticleRow[]) {
 
   for (const article of articles) {
     const articleStr = String(article.article);
-    if (articleStr.startsWith('suppl-') || articleStr.startsWith('amend-')) {
+    if (/^(?:suppl|fusoku|amend|amendment)[_-]/.test(articleStr)) {
       supplementary.push(article);
     } else {
       normal.push(article);

--- a/src/components/StructuredData.tsx
+++ b/src/components/StructuredData.tsx
@@ -1,4 +1,5 @@
 import { ArticleData } from '@/lib/types';
+import { formatArticleNumber } from '@/lib/utils';
 
 interface WebsiteStructuredDataProps {
   name?: string;
@@ -60,12 +61,7 @@ export function ArticleStructuredData({
   lawCategory,
   lawId,
 }: ArticleStructuredDataProps) {
-  const articleNumber =
-    typeof article.article === 'number'
-      ? `第${article.article}条`
-      : article.article.startsWith('suppl-')
-        ? `附則第${article.article.replace('suppl-', '')}条`
-        : `第${article.article}条`;
+  const articleNumber = formatArticleNumber(article.article);
 
   const title = `${lawName} ${articleNumber}`;
   const url = `https://osaka-kenpo.llll-ll.com/law/${lawCategory}/${lawId}/${article.article}`;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { ArticleData } from './types';
+import { formatArticleNumber } from './utils';
 
 /**
  * 条文ページ用のメタデータを生成
@@ -11,12 +12,7 @@ export function generateArticleMetadata(
   lawCategory: string,
   lawId: string
 ): Metadata {
-  const articleNumber =
-    typeof articleData.article === 'number'
-      ? `第${articleData.article}条`
-      : articleData.article.startsWith('suppl-')
-        ? `附則第${articleData.article.replace('suppl-', '')}条`
-        : `第${articleData.article}条`;
+  const articleNumber = formatArticleNumber(articleData.article);
 
   const title = `${lawName} ${articleNumber} - おおさかけんぽう`;
   const description = articleData.osakaText?.[0]

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -30,6 +30,8 @@ export function formatArticleNumber(article: number | string): string {
   if (supplMatch) return `附則第${supplMatch[1]}条`;
   const amendMatch = s.match(/^(?:amend|amendment)[_-](.+)$/);
   if (amendMatch) return `修正第${amendMatch[1]}条`;
+  const branchMatch = s.match(/^(\d+)-(\d+)$/);
+  if (branchMatch) return `第${branchMatch[1]}条の${branchMatch[2]}`;
   return `第${article}条`;
 }
 
@@ -95,9 +97,9 @@ export function getExcerpt(text: string, maxLength: number = 50): string {
  */
 export function getArticleSortKey(article: string): number {
   const supplMatch = article.match(/^(?:suppl|fusoku)[_-](.+)$/);
-  if (supplMatch) return 100000 + parseInt(supplMatch[1], 10);
+  if (supplMatch) return 100000 + (parseInt(supplMatch[1], 10) || 0);
   const amendMatch = article.match(/^(?:amend|amendment)[_-](.+)$/);
-  if (amendMatch) return 200000 + parseInt(amendMatch[1], 10);
+  if (amendMatch) return 200000 + (parseInt(amendMatch[1], 10) || 0);
   const match = article.match(/^(\d+)-(\d+)$/);
   if (match) return parseInt(match[1], 10) + parseInt(match[2], 10) * 0.001;
   const num = parseInt(article, 10);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,12 +21,15 @@ export function sortArticleNumbers(articles: string[]): string[] {
 
 /**
  * 条文番号を整形する（例: "1" -> "第1条", "suppl-1" -> "附則第1条"）
+ * ハイフン・アンダースコアどちらの区切りにも対応
  */
 export function formatArticleNumber(article: number | string): string {
   if (typeof article === 'number') return `第${article}条`;
-  if (String(article).startsWith('suppl-')) {
-    return `附則第${String(article).replace('suppl-', '')}条`;
-  }
+  const s = String(article);
+  const supplMatch = s.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  if (supplMatch) return `附則第${supplMatch[1]}条`;
+  const amendMatch = s.match(/^(?:amend|amendment)[_-](.+)$/);
+  if (amendMatch) return `修正第${amendMatch[1]}条`;
   return `第${article}条`;
 }
 
@@ -91,8 +94,10 @@ export function getExcerpt(text: string, maxLength: number = 50): string {
  * 条文番号のソートキーを返す（枝番・附則・改正対応）
  */
 export function getArticleSortKey(article: string): number {
-  if (article.startsWith('suppl-')) return 100000 + parseInt(article.replace('suppl-', ''), 10);
-  if (article.startsWith('amend-')) return 200000 + parseInt(article.replace('amend-', ''), 10);
+  const supplMatch = article.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  if (supplMatch) return 100000 + parseInt(supplMatch[1], 10);
+  const amendMatch = article.match(/^(?:amend|amendment)[_-](.+)$/);
+  if (amendMatch) return 200000 + parseInt(amendMatch[1], 10);
   const match = article.match(/^(\d+)-(\d+)$/);
   if (match) return parseInt(match[1], 10) + parseInt(match[2], 10) * 0.001;
   const num = parseInt(article, 10);


### PR DESCRIPTION
## 関連 Issue
closes #32

## 変更内容
- `formatArticleNumber()` で suppl_/fusoku_/amendment_ (アンダースコア) と suppl-/amend- (ハイフン) の両方に対応
- `getArticleSortKey()` も同様に両方対応
- seo.ts, StructuredData.tsx, route.tsx の3箇所に重複していたフォーマットロジックを `formatArticleNumber()` に集約
- law/page.tsx の分類ロジックも同様に修正
- ドキュメント（article-naming-convention.md）のコード例を更新