### PR TITLE
fix: 削除された条文をクリック不可にする

### DIFF
--- a/src/app/components/ArticleListItem.tsx
+++ b/src/app/components/ArticleListItem.tsx
@@ -26,65 +26,71 @@ export function ArticleListItem({
   const hasTitle = title && title.trim() !== '';
   const excerpt = !hasTitle && originalText ? getExcerpt(originalText) : '';
 
-  return (
-    <Link href={href}>
-      <div
-        className={`block p-6 rounded-lg shadow-[0_0_15px_rgba(0,0,0,0.05)] hover:shadow-[0_0_20px_rgba(0,0,0,0.1)] transition-shadow cursor-pointer border-l-4 mb-4 relative ${
-          isDeleted ? 'bg-gray-100 border-gray-400' : 'bg-white border-[#E94E77]'
-        }`}
-      >
-        <div className="flex flex-col sm:flex-row sm:items-center pb-4">
-          <span
-            className={`font-bold text-lg mb-2 sm:mb-0 sm:mr-4 shrink-0 ${
-              isDeleted ? 'text-gray-400' : 'text-[#E94E77]'
-            }`}
-          >
-            {formatArticleNumber(article)}
-          </span>
-          {isDeleted ? (
-            <div className="text-gray-400 text-base">（削除）</div>
-          ) : hasTitle ? (
-            <div className="text-gray-800 text-base leading-relaxed">
-              <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(title) }} />
-            </div>
-          ) : excerpt ? (
-            <div className="text-gray-400 text-sm leading-relaxed truncate italic">{excerpt}</div>
-          ) : null}
-        </div>
-
-        {isDeleted && (
-          <div className="absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-bold text-white shadow-md bg-gray-400">
-            削除
+  const innerContent = (
+    <div
+      className={`block p-6 rounded-lg transition-shadow border-l-4 mb-4 relative ${
+        isDeleted
+          ? 'bg-gray-100 border-gray-400 cursor-default shadow-[0_0_15px_rgba(0,0,0,0.05)]'
+          : 'bg-white border-[#E94E77] cursor-pointer shadow-[0_0_15px_rgba(0,0,0,0.05)] hover:shadow-[0_0_20px_rgba(0,0,0,0.1)]'
+      }`}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-center pb-4">
+        <span
+          className={`font-bold text-lg mb-2 sm:mb-0 sm:mr-4 shrink-0 ${
+            isDeleted ? 'text-gray-400' : 'text-[#E94E77]'
+          }`}
+        >
+          {formatArticleNumber(article)}
+        </span>
+        {isDeleted ? (
+          <div className="text-gray-400 text-base">（削除）</div>
+        ) : hasTitle ? (
+          <div className="text-gray-800 text-base leading-relaxed">
+            <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(title) }} />
           </div>
-        )}
-        {!isDeleted && famousArticleBadge && (
-          <div className="absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-bold text-white shadow-md bg-slate-500">
-            {famousArticleBadge}
-          </div>
-        )}
-        {!isDeleted && (
-          <div
-            className={`absolute bottom-3 right-4 flex items-center gap-1 text-xs ${
-              isLiked ? 'text-[#E94E77]' : 'text-gray-400'
-            }`}
-          >
-            <svg
-              className="w-3.5 h-3.5"
-              fill={isLiked ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-              />
-            </svg>
-            <span>{likeCount} ええやん</span>
-          </div>
-        )}
+        ) : excerpt ? (
+          <div className="text-gray-400 text-sm leading-relaxed truncate italic">{excerpt}</div>
+        ) : null}
       </div>
-    </Link>
+
+      {isDeleted && (
+        <div className="absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-bold text-white shadow-md bg-gray-400">
+          削除
+        </div>
+      )}
+      {!isDeleted && famousArticleBadge && (
+        <div className="absolute top-3 right-3 px-2 py-1 rounded-full text-xs font-bold text-white shadow-md bg-slate-500">
+          {famousArticleBadge}
+        </div>
+      )}
+      {!isDeleted && (
+        <div
+          className={`absolute bottom-3 right-4 flex items-center gap-1 text-xs ${
+            isLiked ? 'text-[#E94E77]' : 'text-gray-400'
+          }`}
+        >
+          <svg
+            className="w-3.5 h-3.5"
+            fill={isLiked ? 'currentColor' : 'none'}
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+            />
+          </svg>
+          <span>{likeCount} ええやん</span>
+        </div>
+      )}
+    </div>
   );
+
+  if (isDeleted) {
+    return innerContent;
+  }
+
+  return <Link href={href}>{innerContent}</Link>;
 }

--- a/src/app/components/ArticleListItem.tsx
+++ b/src/app/components/ArticleListItem.tsx
@@ -33,6 +33,9 @@ export function ArticleListItem({
           ? 'bg-gray-100 border-gray-400 cursor-default shadow-[0_0_15px_rgba(0,0,0,0.05)]'
           : 'bg-white border-[#E94E77] cursor-pointer shadow-[0_0_15px_rgba(0,0,0,0.05)] hover:shadow-[0_0_20px_rgba(0,0,0,0.1)]'
       }`}
+      {...(isDeleted
+        ? { 'aria-disabled': true, 'aria-label': `${formatArticleNumber(article)} 削除済み` }
+        : {})}
     >
       <div className="flex flex-col sm:flex-row sm:items-center pb-4">
         <span

--- a/src/app/law/[law_category]/[law]/[article]/page.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/page.tsx
@@ -107,6 +107,29 @@ export default async function ArticlePage({
   const lawName =
     lawMetadata?.short_name || lawMetadata?.display_name || staticLaw?.shortName || law;
 
+  // 削除された条文の場合
+  if (articleRow.is_deleted === 1) {
+    return (
+      <div className="min-h-screen bg-cream">
+        <div className="container mx-auto px-4 py-8">
+          <div className="max-w-2xl mx-auto bg-white rounded-lg shadow-[0_0_20px_rgba(0,0,0,0.08)] p-8 text-center">
+            <div className="text-gray-400 text-5xl mb-6">§</div>
+            <h1 className="text-2xl font-bold text-gray-400 mb-4">
+              {formatArticleNumber(article)}
+            </h1>
+            <p className="text-gray-500 text-lg mb-8">この条文は削除されています</p>
+            <a
+              href={`/law/${law_category}/${law}`}
+              className="inline-block bg-[#E94E77] hover:bg-opacity-80 text-white rounded-lg font-bold px-6 py-3 transition-colors"
+            >
+              {lawName} の条文一覧に戻る
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // D1のカラムからArticleData形式に変換
   const articleData = {
     article: articleRow.article,

--- a/src/app/law/[law_category]/[law]/[article]/page.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/page.tsx
@@ -17,6 +17,14 @@ export async function generateMetadata({
 
   const articleRow = await getArticle(law_category, law, article);
   const articleLabel = formatArticleNumber(article);
+
+  if (articleRow?.is_deleted === 1) {
+    return {
+      title: `${articleLabel}（削除） - ${lawName} - おおさかけんぽう`,
+      robots: { index: false },
+    };
+  }
+
   const articleTitle = articleRow?.title ? `${articleLabel}（${articleRow.title}）` : articleLabel;
   const title = `${articleTitle} - ${lawName} - おおさかけんぽう`;
 


### PR DESCRIPTION
## 関連 Issue
closes #34

## 変更内容
- 条文一覧で削除条文のリンクを無効化（Link → div、cursor-default、hover効果除去）
- 直接URLアクセス時に「この条文は削除されています」メッセージ + 戻りリンクを表示