### PR TITLE
fix: 原文表示時のフッタ下レイアウト崩れを修正

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="bg-cream">
       {/* 右上にシェアボタン */}
       <div className="fixed top-20 right-4 z-10">
         <ShareButton />

--- a/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
@@ -62,7 +62,7 @@ export function ArticleClient({
   });
 
   return (
-    <main className="min-h-screen bg-cream relative">
+    <div className="bg-cream relative">
       {/* 左上に戻るリンク */}
       <div className="fixed top-20 left-4 z-10">
         <ScrollAwareBackLink href={`/law/${lawCategory}/${law}`}>条文一覧へ</ScrollAwareBackLink>
@@ -116,6 +116,6 @@ export function ArticleClient({
           </div>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/law/[law_category]/[law]/[article]/page.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/page.tsx
@@ -82,7 +82,7 @@ export default async function ArticlePage({
   } catch (error) {
     console.error('DB Error:', error);
     return (
-      <div className="min-h-screen bg-cream">
+      <div className="bg-cream">
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6 text-center">
             <h1 className="text-2xl font-bold text-primary mb-4">データ取得エラー</h1>
@@ -98,7 +98,7 @@ export default async function ArticlePage({
 
   if (!articleRow) {
     return (
-      <div className="min-h-screen bg-cream">
+      <div className="bg-cream">
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6 text-center">
             <h1 className="text-2xl font-bold text-primary mb-4">条文が見つかりません</h1>
@@ -118,7 +118,7 @@ export default async function ArticlePage({
   // 削除された条文の場合
   if (articleRow.is_deleted === 1) {
     return (
-      <div className="min-h-screen bg-cream">
+      <div className="bg-cream">
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-2xl mx-auto bg-white rounded-lg shadow-[0_0_20px_rgba(0,0,0,0.08)] p-8 text-center">
             <div className="text-gray-400 text-5xl mb-6">§</div>

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -179,7 +179,7 @@ export default async function LawArticlesPage({
 
   if (!articles || articles.length === 0) {
     return (
-      <div className="min-h-screen bg-cream flex items-center justify-center">
+      <div className="bg-cream flex items-center justify-center">
         <div className="text-center">
           <div className="text-gray-600 text-xl mb-4">条文が見つかりませんでした。</div>
           <a href="/" className="text-blue-600 hover:underline">
@@ -229,7 +229,7 @@ export default async function LawArticlesPage({
   const isSupplPage = pageParam === 'suppl';
 
   return (
-    <div className="min-h-screen bg-cream">
+    <div className="bg-cream">
       {/* 左上に戻るリンク */}
       <div className="fixed top-20 left-4 z-10">
         <ScrollAwareBackLink href="/">法律一覧へ</ScrollAwareBackLink>


### PR DESCRIPTION
## 関連 Issue
closes #35

## 変更内容
- layout.tsx の flex レイアウトと二重になっていた `min-h-screen` を4ファイルから除去
- ArticleClient.tsx の二重 `<main>` タグを `<div>` に修正
- `min-h-screen` は layout.tsx の body と ErrorBoundary のフォールバックにのみ残存