### PR TITLE
refactor: 旧形式article IDの防御コードを除去

### DIFF
--- a/docs/article-naming-convention.md
+++ b/docs/article-naming-convention.md
@@ -241,12 +241,15 @@ src/data/laws/
 export function formatArticleNumber(article: number | string): string {
   if (typeof article === 'number') return `第${article}条`;
   const s = String(article);
-  // 附則（suppl / fusoku、ハイフン・アンダースコア両対応）
-  const supplMatch = s.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  // 附則（正規形式: suppl-N のみ）
+  const supplMatch = s.match(/^suppl-(.+)$/);
   if (supplMatch) return `附則第${supplMatch[1]}条`;
-  // 修正条項（amend / amendment、同上）
-  const amendMatch = s.match(/^(?:amend|amendment)[_-](.+)$/);
+  // 修正条項（正規形式: amend-N のみ）
+  const amendMatch = s.match(/^amend-(.+)$/);
   if (amendMatch) return `修正第${amendMatch[1]}条`;
+  // 枝番（121-2 等）
+  const branchMatch = s.match(/^(\d+)-(\d+)$/);
+  if (branchMatch) return `第${branchMatch[1]}条の${branchMatch[2]}`;
   return `第${article}条`;
 }
 ```

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -61,8 +61,8 @@ function getFirstParagraph(originalTextJson: string | null | undefined): string 
 
 // 条文番号から基本番号を抽出（1-2 → 1, 876-5 → 876）
 function getBaseArticleNumber(article: string): number {
-  // suppl-1 や amend-1 は特別扱い（アンダースコア / fusoku / amendment も対応）
-  if (/^(?:suppl|fusoku|amend|amendment)[_-]/.test(article)) {
+  // suppl-1 や amend-1 は特別扱い
+  if (/^(?:suppl|amend)-/.test(article)) {
     return -1; // 附則は別扱い
   }
   // 枝番（1-2など）は基本番号を返す
@@ -80,7 +80,7 @@ function classifyArticles(articles: ArticleRow[]) {
 
   for (const article of articles) {
     const articleStr = String(article.article);
-    if (/^(?:suppl|fusoku|amend|amendment)[_-]/.test(articleStr)) {
+    if (/^(?:suppl|amend)-/.test(articleStr)) {
       supplementary.push(article);
     } else {
       normal.push(article);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,14 +21,14 @@ export function sortArticleNumbers(articles: string[]): string[] {
 
 /**
  * 条文番号を整形する（例: "1" -> "第1条", "suppl-1" -> "附則第1条"）
- * ハイフン・アンダースコアどちらの区切りにも対応
+ * 正規形式のみ受け付ける（suppl-N, amend-N）。旧形式（fusoku_, amendment_, アンダースコア）は不正データ
  */
 export function formatArticleNumber(article: number | string): string {
   if (typeof article === 'number') return `第${article}条`;
   const s = String(article);
-  const supplMatch = s.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  const supplMatch = s.match(/^suppl-(.+)$/);
   if (supplMatch) return `附則第${supplMatch[1]}条`;
-  const amendMatch = s.match(/^(?:amend|amendment)[_-](.+)$/);
+  const amendMatch = s.match(/^amend-(.+)$/);
   if (amendMatch) return `修正第${amendMatch[1]}条`;
   const branchMatch = s.match(/^(\d+)-(\d+)$/);
   if (branchMatch) return `第${branchMatch[1]}条の${branchMatch[2]}`;
@@ -96,9 +96,9 @@ export function getExcerpt(text: string, maxLength: number = 50): string {
  * 条文番号のソートキーを返す（枝番・附則・改正対応）
  */
 export function getArticleSortKey(article: string): number {
-  const supplMatch = article.match(/^(?:suppl|fusoku)[_-](.+)$/);
+  const supplMatch = article.match(/^suppl-(.+)$/);
   if (supplMatch) return 100000 + (parseInt(supplMatch[1], 10) || 0);
-  const amendMatch = article.match(/^(?:amend|amendment)[_-](.+)$/);
+  const amendMatch = article.match(/^amend-(.+)$/);
   if (amendMatch) return 200000 + (parseInt(amendMatch[1], 10) || 0);
   const match = article.match(/^(\d+)-(\d+)$/);
   if (match) return parseInt(match[1], 10) + parseInt(match[2], 10) * 0.001;


### PR DESCRIPTION
## 変更内容
PR#39 でYAMLデータを正規形式（suppl-N, amend-N）に統一したため、旧形式（fusoku_, amendment_, アンダースコア区切り）の防御コードを除去。

不正データが混入した場合、表示が壊れて検知できるようにする。

- `formatArticleNumber()`: `suppl-` と `amend-` のみマッチ
- `getArticleSortKey()`: 同上
- `classifyArticles()` / `getBaseArticleNumber()`: 同上
- ドキュメントのコード例を更新