### PR TITLE
fix: #35 原文表示時のフッタ下余白レイアウト崩れを修正

### DIFF
--- a/src/app/components/AnimatedContent.tsx
+++ b/src/app/components/AnimatedContent.tsx
@@ -1,58 +1,45 @@
-'use client'
+'use client';
 
 interface AnimatedContentProps {
-  originalContent: React.ReactNode
-  osakaContent: React.ReactNode
-  showOsaka: boolean
-  className?: string
+  originalContent: React.ReactNode;
+  osakaContent: React.ReactNode;
+  showOsaka: boolean;
+  className?: string;
 }
 
-export const AnimatedContent = ({ 
-  originalContent, 
-  osakaContent, 
-  showOsaka, 
-  className = '' 
+export const AnimatedContent = ({
+  originalContent,
+  osakaContent,
+  showOsaka,
+  className = '',
 }: AnimatedContentProps) => {
   return (
-    <div className={`relative ${className}`}>
-      {/* 高さ確保用の非表示要素 */}
-      <div style={{ visibility: 'hidden', position: 'relative' }}>
-        {showOsaka ? osakaContent : originalContent}
-      </div>
-      
+    <div className={`grid ${className}`} style={{ gridTemplateAreas: '"content"' }}>
       {/* 原文コンテンツ */}
       <div
         className="transition-opacity duration-500 ease-in-out"
-        style={{ 
+        style={{
+          gridArea: 'content',
           opacity: showOsaka ? 0 : 1,
-          position: 'absolute',
-          top: '0px',
-          left: '0px',
-          right: '0px',
-          margin: 0,
-          padding: 0,
-          pointerEvents: showOsaka ? 'none' : 'auto'
+          pointerEvents: showOsaka ? 'none' : 'auto',
         }}
+        aria-hidden={showOsaka}
       >
         {originalContent}
       </div>
-      
+
       {/* 大阪弁コンテンツ */}
       <div
         className="transition-opacity duration-500 ease-in-out"
-        style={{ 
+        style={{
+          gridArea: 'content',
           opacity: showOsaka ? 1 : 0,
-          position: 'absolute',
-          top: '0px',
-          left: '0px',
-          right: '0px',
-          margin: 0,
-          padding: 0,
-          pointerEvents: showOsaka ? 'auto' : 'none'
+          pointerEvents: showOsaka ? 'auto' : 'none',
         }}
+        aria-hidden={!showOsaka}
       >
         {osakaContent}
       </div>
     </div>
-  )
-}
+  );
+};


### PR DESCRIPTION
## 関連 Issue
closes #35

## 変更内容
- AnimatedContent の高さ確保方式を `visibility:hidden` + `position:absolute` から CSS Grid 重ね合わせに変更
- 同一 `grid-area` に原文・大阪弁を配置することで、コンテナ高さが常に両者の最大値になる
- 表示切替時の高さ縮小によるフッタ下余白が発生しなくなる

## 再現手順
1. スマホ幅（375px）で条文ページにアクセス
2. 原文表示に切り替え
3. フッタより下にスクロールできてしまう → 修正後は不可