### PR TITLE
fix: #44 カウンター表示が0のまま更新されない問題を修正

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -341,7 +341,7 @@ GET {BASE}?action=get&id={counterId}&format=json
 ```
 
 **使用箇所**: `ArticleViewCounter`（条文詳細ページ）
-**キャッシュ**: `sessionStorage` で5分間キャッシュ
+**キャッシュ**: `sessionStorage` で30秒間キャッシュ
 
 #### 3.2.3 sumByPrefix — プレフィックスで合計取得
 
@@ -415,9 +415,9 @@ Content-Type: application/json
 
 | コンポーネント                         | キャッシュ先        | TTL            | 無効化                             |
 | -------------------------------------- | ------------------- | -------------- | ---------------------------------- |
-| `LawCardWithEeyan`                     | sessionStorage      | 5分            | `visibilitychange` で削除 + 再取得 |
-| `TotalViewCounter`（合計値）           | sessionStorage      | 5分            | なし                               |
-| `ArticleViewCounter`（値）             | sessionStorage      | 5分            | increment 直後はキャッシュ無視     |
+| `LawCardWithEeyan`                     | sessionStorage      | 30秒           | `visibilitychange` で削除 + 再取得 |
+| `TotalViewCounter`（合計値）           | sessionStorage      | 30秒           | なし                               |
+| `ArticleViewCounter`（値）             | sessionStorage      | 30秒           | increment 直後はキャッシュ無視     |
 | `ArticleViewCounter`（インクリメント） | sessionStorage      | セッション中   | なし                               |
 | `LikeButton`                           | なし                | -              | マウント時に毎回取得               |
 | `ArticleListWithEeyan`                 | なし                | -              | `visibilitychange` で再取得        |

--- a/docs/eeyan-spec.md
+++ b/docs/eeyan-spec.md
@@ -365,7 +365,7 @@ interface OsakaKenpoStorage {
 | `eeyan_total_{category}_{lawName}`      | 数値（文字列）           | 合計いいね数      |
 | `eeyan_total_{category}_{lawName}_time` | タイムスタンプ（文字列） | `Date.now()` の値 |
 
-**TTL**: 5分（`5 * 60 * 1000` ミリ秒）。TTL 内はキャッシュから `setTotalLikes()` して API リクエストしない。
+**TTL**: 30秒（`30 * 1000` ミリ秒）。TTL 内はキャッシュから `setTotalLikes()` して API リクエストしない。
 
 **キャッシュ無効化**: `visibilitychange` イベントで `visible` になったとき、sessionStorage の該当キー2つを `removeItem()` してから `fetchTotalLikes()` を再呼び出しする。
 
@@ -524,7 +524,7 @@ sequenceDiagram
     LCE->>SS: getItem(eeyan_total_{cat}_{law})
     LCE->>SS: getItem(eeyan_total_{cat}_{law}_time)
 
-    alt キャッシュあり & 5分以内
+    alt キャッシュあり & 30秒以内
         SS-->>LCE: cached value
         LCE->>LCE: setTotalLikes(Number(cached))
     else キャッシュなし or 期限切れ
@@ -754,7 +754,7 @@ QRコードに加え、ユーザーIDを直接コピーする手段も提供:
 | 項目   | 値                                                              |
 | ------ | --------------------------------------------------------------- |
 | 対象   | トップページの法律カード合計いいね数                            |
-| TTL    | 5分（`5 * 60 * 1000` ms）                                       |
+| TTL    | 30秒（`30 * 1000` ms）                                          |
 | キー   | `eeyan_total_{category}_{lawName}` + `_time`                    |
 | 無効化 | `visibilitychange` で `visible` になったとき: キー削除 → 再取得 |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -108,7 +108,7 @@ interface EeyanContextType {
 
 **動作フロー**:
 
-1. `sessionStorage` のキャッシュをチェック（TTL: 5分）
+1. `sessionStorage` のキャッシュをチェック（TTL: 30秒）
 2. キャッシュがあればそれを表示
 3. なければ Nostalgic Counter API の `sumByPrefix`（prefix: `osaka-kenpo-`）で全条文の合計を取得
 4. 結果を `sessionStorage` にキャッシュ
@@ -137,7 +137,7 @@ interface ArticleViewCounterProps {
    - `sessionStorage` にフラグを記録
 2. **表示値取得**:
    - インクリメント直後はキャッシュを無視して最新値を取得
-   - それ以外は `sessionStorage` のキャッシュをチェック（TTL: 5分）
+   - それ以外は `sessionStorage` のキャッシュをチェック（TTL: 30秒）
    - Nostalgic Counter API の `get`（format: json）で取得
    - 結果を `sessionStorage` にキャッシュ
 

--- a/src/app/components/ArticleViewCounter.tsx
+++ b/src/app/components/ArticleViewCounter.tsx
@@ -13,7 +13,7 @@ interface ArticleViewCounterProps {
   law: string;
 }
 
-const CACHE_DURATION = 5 * 60 * 1000; // 5分
+const CACHE_DURATION = 30 * 1000; // 30秒
 
 /**
  * 条文ページの閲覧数カウンター
@@ -40,11 +40,13 @@ export function ArticleViewCounter({ articleId, lawCategory, law }: ArticleViewC
 
         if (!alreadyIncremented && !hasIncremented.current) {
           const incrementUrl = `${NOSTALGIC_COUNTER_API_BASE}?action=increment&id=${encodeURIComponent(counterId)}`;
-          await fetch(incrementUrl);
-          safeSessionSet(sessionKey, 'true');
-          hasIncremented.current = true;
-          didIncrement = true;
-          notifyChanged();
+          const incrementRes = await fetch(incrementUrl);
+          if (incrementRes.ok) {
+            safeSessionSet(sessionKey, 'true');
+            hasIncremented.current = true;
+            didIncrement = true;
+          }
+          // 失敗時はマークしない（次回再試行可能）
         }
 
         // increment 直後はキャッシュを無視して最新値を取得
@@ -59,13 +61,21 @@ export function ArticleViewCounter({ articleId, lawCategory, law }: ArticleViewC
         ) {
           setCount(parseInt(cached));
         } else {
+          // increment直後はサーバー側の反映を待つ
+          if (didIncrement) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+          }
           const displayUrl = `${NOSTALGIC_COUNTER_API_BASE}?action=get&id=${encodeURIComponent(counterId)}&format=json`;
           const response = await fetch(displayUrl);
+          if (!response.ok) return;
           const data = (await response.json()) as { success: boolean; data: { total: number } };
           if (data.success) {
             setCount(data.data.total);
             safeSessionSet(cacheKey, String(data.data.total));
             safeSessionSet(cacheTimeKey, String(Date.now()));
+            if (didIncrement) {
+              notifyChanged();
+            }
           }
         }
       } catch (error) {

--- a/src/app/components/ArticleViewCounter.tsx
+++ b/src/app/components/ArticleViewCounter.tsx
@@ -67,7 +67,10 @@ export function ArticleViewCounter({ articleId, lawCategory, law }: ArticleViewC
           }
           const displayUrl = `${NOSTALGIC_COUNTER_API_BASE}?action=get&id=${encodeURIComponent(counterId)}&format=json`;
           const response = await fetch(displayUrl);
-          if (!response.ok) return;
+          if (!response.ok) {
+            logger.warn('Counter get API failed', { status: response.status, counterId });
+            return;
+          }
           const data = (await response.json()) as { success: boolean; data: { total: number } };
           if (data.success) {
             setCount(data.data.total);

--- a/src/app/components/LawCardWithEeyan.tsx
+++ b/src/app/components/LawCardWithEeyan.tsx
@@ -32,14 +32,17 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
     // Check sessionStorage cache (5 min)
     const cached = safeSessionGet(cacheKey);
     const cachedTime = safeSessionGet(cacheTimeKey);
-    if (cached && cachedTime && Date.now() - Number(cachedTime) < 5 * 60 * 1000) {
+    if (cached && cachedTime && Date.now() - Number(cachedTime) < 30 * 1000) {
       setTotalLikes(Number(cached));
       return;
     }
 
     const prefix = `osaka-kenpo-${category}-${lawName}-`;
     fetch(`${NOSTALGIC_API_BASE}?action=sumByPrefix&prefix=${prefix}`)
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
       .then((data) => {
         const d = data as { success: boolean; total: number };
         if (d.success) {
@@ -64,14 +67,17 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
 
     const cached = safeSessionGet(cacheKey);
     const cachedTime = safeSessionGet(cacheTimeKey);
-    if (cached && cachedTime && Date.now() - Number(cachedTime) < 5 * 60 * 1000) {
+    if (cached && cachedTime && Date.now() - Number(cachedTime) < 30 * 1000) {
       setTotalViews(Number(cached));
       return;
     }
 
     const prefix = `osaka-kenpo-${category}-${lawName}-`;
     fetch(`${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=${prefix}`)
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
       .then((data) => {
         const d = data as { success: boolean; total: number };
         if (d.success) {

--- a/src/app/components/LawCardWithEeyan.tsx
+++ b/src/app/components/LawCardWithEeyan.tsx
@@ -12,6 +12,8 @@ interface LawCardWithEeyanProps {
   law: LawEntry;
 }
 
+const CACHE_DURATION = 30 * 1000; // 30秒
+
 export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
   const [totalLikes, setTotalLikes] = useState<number>(0);
   const [totalViews, setTotalViews] = useState<number>(0);
@@ -29,10 +31,9 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
     const cacheKey = `eeyan_total_${category}_${lawName}`;
     const cacheTimeKey = `${cacheKey}_time`;
 
-    // Check sessionStorage cache (5 min)
     const cached = safeSessionGet(cacheKey);
     const cachedTime = safeSessionGet(cacheTimeKey);
-    if (cached && cachedTime && Date.now() - Number(cachedTime) < 30 * 1000) {
+    if (cached && cachedTime && Date.now() - Number(cachedTime) < CACHE_DURATION) {
       setTotalLikes(Number(cached));
       return;
     }
@@ -67,7 +68,7 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
 
     const cached = safeSessionGet(cacheKey);
     const cachedTime = safeSessionGet(cacheTimeKey);
-    if (cached && cachedTime && Date.now() - Number(cachedTime) < 30 * 1000) {
+    if (cached && cachedTime && Date.now() - Number(cachedTime) < CACHE_DURATION) {
       setTotalViews(Number(cached));
       return;
     }

--- a/src/app/components/TotalViewCounter.tsx
+++ b/src/app/components/TotalViewCounter.tsx
@@ -30,7 +30,10 @@ export function TotalViewCounter() {
       const res = await fetch(
         `${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=osaka-kenpo-`
       );
-      if (!res.ok) return;
+      if (!res.ok) {
+        logger.warn('Total view counter API failed', { status: res.status });
+        return;
+      }
       const data = (await res.json()) as { success: boolean; total: number };
       if (data.success) {
         setTotal(data.total);

--- a/src/app/components/TotalViewCounter.tsx
+++ b/src/app/components/TotalViewCounter.tsx
@@ -8,7 +8,7 @@ import { useEeyanRevision } from '@/app/context/EeyanContext';
 
 const CACHE_KEY = 'counter_total_all';
 const CACHE_TIME_KEY = 'counter_total_all_time';
-const CACHE_DURATION = 5 * 60 * 1000; // 5分
+const CACHE_DURATION = 30 * 1000; // 30秒
 
 /**
  * 全条文の閲覧数合計を表示するコンポーネント
@@ -30,6 +30,7 @@ export function TotalViewCounter() {
       const res = await fetch(
         `${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=osaka-kenpo-`
       );
+      if (!res.ok) return;
       const data = (await res.json()) as { success: boolean; total: number };
       if (data.success) {
         setTotal(data.total);


### PR DESCRIPTION
## 関連 Issue
closes #44

## 変更内容

### 根本原因
nostalgic API（api.nostalgic.llll-ll.com）のCORS設定でPOSTリクエストの許可リストに`osaka-kenpo.llll-ll.com`が含まれておらず、`batchGet`（POST）がブラウザにブロックされていた。これにより条文一覧・法律一覧・トップページのカウンター取得が全て失敗し、0のまま表示されていた。

→ **nostalgic API側を修正済み・デプロイ済み**（`*.llll-ll.com`全体を許可に拡張）

### osaka-kenpo側の改善（防御的修正）
1. **ArticleViewCounter**: increment APIのレスポンスチェック追加。失敗時はsessionStorageにマークしない（次回再試行可能）。increment後200msディレイしてget API呼び出し（サーバー反映待ち）。notifyChanged()をget完了後に移動（競争条件解消）
2. **LawCardWithEeyan**: fetch呼び出しにresponse.okチェック追加
3. **TotalViewCounter**: fetch呼び出しにresponse.okチェック追加
4. **全コンポーネント共通**: sessionStorageキャッシュ期間を5分→30秒に短縮
5. **ドキュメント更新**: docs/api.md, docs/eeyan-spec.md, docs/features.md のキャッシュ期間記述を更新

## テスト結果（本番サイトで確認済み）
- [x] 条文ページを開く → カウンターが表示される（2）
- [x] 条文一覧に戻る → 該当条文のカウンターが反映されている（2）
- [x] 法律一覧に戻る → その法律の合計カウンターが反映されている（2）
- [x] CORSエラーが解消されている（コンソールエラー9件→1件、残りはCSP関連で無関係）