### PR TITLE
fix: #45 条文一覧へ戻る時にページ位置を復元する

### DIFF
--- a/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useViewMode } from '@/app/context/ViewModeContext';
 import { ArticleNavigation } from '@/app/components/ArticleNavigation';
 import { ScrollAwareBackLink } from '@/app/components/navigation/ScrollAwareBackLink';
@@ -37,6 +38,16 @@ export function ArticleClient({
 }: ArticleClientProps) {
   const { viewMode, setViewMode } = useViewMode();
 
+  // sessionStorage からページ番号を読み取り、戻りリンクに反映
+  const basePath = `/law/${lawCategory}/${law}`;
+  const [backHref, setBackHref] = useState(basePath);
+  useEffect(() => {
+    const savedPage = sessionStorage.getItem(`osaka-kenpo-page-${lawCategory}-${law}`);
+    if (savedPage && parseInt(savedPage, 10) > 1) {
+      setBackHref(`${basePath}?page=${savedPage}`);
+    }
+  }, [basePath, lawCategory, law]);
+
   const showOsaka = viewMode === 'osaka';
 
   const toggleViewMode = () => {
@@ -65,7 +76,7 @@ export function ArticleClient({
     <div className="bg-cream relative">
       {/* 左上に戻るリンク */}
       <div className="fixed top-20 left-4 z-10">
-        <ScrollAwareBackLink href={`/law/${lawCategory}/${law}`}>条文一覧へ</ScrollAwareBackLink>
+        <ScrollAwareBackLink href={backHref}>条文一覧へ</ScrollAwareBackLink>
       </div>
 
       <ArticleNavigationButtons

--- a/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useViewMode } from '@/app/context/ViewModeContext';
+import { safeSessionGet } from '@/lib/storage';
 import { ArticleNavigation } from '@/app/components/ArticleNavigation';
 import { ScrollAwareBackLink } from '@/app/components/navigation/ScrollAwareBackLink';
 import { useArticleNavigation } from '@/hooks/useArticleNavigation';
@@ -42,9 +43,10 @@ export function ArticleClient({
   const basePath = `/law/${lawCategory}/${law}`;
   const [backHref, setBackHref] = useState(basePath);
   useEffect(() => {
-    const savedPage = sessionStorage.getItem(`osaka-kenpo-page-${lawCategory}-${law}`);
-    if (savedPage && parseInt(savedPage, 10) > 1) {
-      setBackHref(`${basePath}?page=${savedPage}`);
+    const savedPage = safeSessionGet(`osaka-kenpo-page-${lawCategory}-${law}`);
+    const parsed = parseInt(savedPage ?? '', 10);
+    if (parsed > 1) {
+      setBackHref(`${basePath}?page=${parsed}`);
     }
   }, [basePath, lawCategory, law]);
 

--- a/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/ArticleClient.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useViewMode } from '@/app/context/ViewModeContext';
-import { safeSessionGet } from '@/lib/storage';
+import { safeSessionGet, getPageStorageKey } from '@/lib/storage';
 import { ArticleNavigation } from '@/app/components/ArticleNavigation';
 import { ScrollAwareBackLink } from '@/app/components/navigation/ScrollAwareBackLink';
 import { useArticleNavigation } from '@/hooks/useArticleNavigation';
@@ -43,7 +43,7 @@ export function ArticleClient({
   const basePath = `/law/${lawCategory}/${law}`;
   const [backHref, setBackHref] = useState(basePath);
   useEffect(() => {
-    const savedPage = safeSessionGet(`osaka-kenpo-page-${lawCategory}-${law}`);
+    const savedPage = safeSessionGet(getPageStorageKey(lawCategory, law));
     const parsed = parseInt(savedPage ?? '', 10);
     if (parsed > 1) {
       setBackHref(`${basePath}?page=${parsed}`);

--- a/src/app/law/[law_category]/[law]/[article]/components/ArticleHeader.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/components/ArticleHeader.tsx
@@ -16,7 +16,7 @@ export function ArticleHeader({ article, title, titleOsaka, showOsaka }: Article
         showOsaka={showOsaka}
         originalContent={
           <h1 className="text-2xl font-bold mb-6">
-            <span className="text-[#E94E77]">{formatArticleNumber(article)} </span>
+            <span className="text-[#E94E77] mr-3">{formatArticleNumber(article)}</span>
             <span
               className="text-gray-800"
               dangerouslySetInnerHTML={{ __html: sanitizeHtml(title) }}
@@ -25,7 +25,7 @@ export function ArticleHeader({ article, title, titleOsaka, showOsaka }: Article
         }
         osakaContent={
           <h1 className="text-2xl font-bold mb-6">
-            <span className="text-[#E94E77]">{formatArticleNumber(article)} </span>
+            <span className="text-[#E94E77] mr-3">{formatArticleNumber(article)}</span>
             <span className="text-gray-800">{titleOsaka || title}</span>
           </h1>
         }

--- a/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
+++ b/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
@@ -9,7 +9,12 @@ import {
   getEeyanUserId,
   getNostalgicId,
 } from '@/lib/eeyan';
+import { safeSessionSet, safeSessionRemove } from '@/lib/storage';
 import { useEeyanRevision } from '@/app/context/EeyanContext';
+
+function getPageStorageKey(lawCategory: string, law: string): string {
+  return `osaka-kenpo-page-${lawCategory}-${law}`;
+}
 
 interface ArticleData {
   article: string;
@@ -157,9 +162,9 @@ export function ArticleListWithEeyan({
   // ページ番号を sessionStorage に保存（条文詳細から戻る時に復元するため）
   useEffect(() => {
     if (currentPage != null && currentPage > 1) {
-      sessionStorage.setItem(`osaka-kenpo-page-${lawCategory}-${law}`, String(currentPage));
+      safeSessionSet(getPageStorageKey(lawCategory, law), String(currentPage));
     } else if (currentPage != null) {
-      sessionStorage.removeItem(`osaka-kenpo-page-${lawCategory}-${law}`);
+      safeSessionRemove(getPageStorageKey(lawCategory, law));
     }
   }, [currentPage, lawCategory, law]);
 

--- a/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
+++ b/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
@@ -24,9 +24,15 @@ interface ArticleListWithEeyanProps {
   articles: ArticleData[];
   lawCategory: string;
   law: string;
+  currentPage?: number;
 }
 
-export function ArticleListWithEeyan({ articles, lawCategory, law }: ArticleListWithEeyanProps) {
+export function ArticleListWithEeyan({
+  articles,
+  lawCategory,
+  law,
+  currentPage,
+}: ArticleListWithEeyanProps) {
   const [likeCounts, setLikeCounts] = useState<Record<string, number>>({});
   const [viewCounts, setViewCounts] = useState<Record<string, number>>({});
   const [userLikes, setUserLikes] = useState<Set<string>>(new Set());
@@ -147,6 +153,15 @@ export function ArticleListWithEeyan({ articles, lawCategory, law }: ArticleList
       clearTimeout(visibilityTimerRef.current);
     };
   }, [fetchEeyanData]);
+
+  // ページ番号を sessionStorage に保存（条文詳細から戻る時に復元するため）
+  useEffect(() => {
+    if (currentPage != null && currentPage > 1) {
+      sessionStorage.setItem(`osaka-kenpo-page-${lawCategory}-${law}`, String(currentPage));
+    } else if (currentPage != null) {
+      sessionStorage.removeItem(`osaka-kenpo-page-${lawCategory}-${law}`);
+    }
+  }, [currentPage, lawCategory, law]);
 
   return (
     <>

--- a/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
+++ b/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
@@ -9,12 +9,8 @@ import {
   getEeyanUserId,
   getNostalgicId,
 } from '@/lib/eeyan';
-import { safeSessionSet, safeSessionRemove } from '@/lib/storage';
+import { safeSessionSet, safeSessionRemove, getPageStorageKey } from '@/lib/storage';
 import { useEeyanRevision } from '@/app/context/EeyanContext';
-
-function getPageStorageKey(lawCategory: string, law: string): string {
-  return `osaka-kenpo-page-${lawCategory}-${law}`;
-}
 
 interface ArticleData {
   article: string;

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -284,7 +284,6 @@ export default async function LawArticlesPage({
                 articles={toArticleData(supplementary, law_category, law, famousArticles, true)}
                 lawCategory={law_category}
                 law={law}
-                currentPage={currentPage}
               />
             </div>
           ) : hasChapters && !needsPagination ? (
@@ -330,7 +329,6 @@ export default async function LawArticlesPage({
                 articles={toArticleData(supplementary, law_category, law, famousArticles, true)}
                 lawCategory={law_category}
                 law={law}
-                currentPage={currentPage}
               />
             </div>
           )}

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -284,6 +284,7 @@ export default async function LawArticlesPage({
                 articles={toArticleData(supplementary, law_category, law, famousArticles, true)}
                 lawCategory={law_category}
                 law={law}
+                currentPage={currentPage}
               />
             </div>
           ) : hasChapters && !needsPagination ? (
@@ -305,6 +306,7 @@ export default async function LawArticlesPage({
                     articles={toArticleData(chapterArticles, law_category, law, famousArticles)}
                     lawCategory={law_category}
                     law={law}
+                    currentPage={currentPage}
                   />
                 </div>
               ))
@@ -314,6 +316,7 @@ export default async function LawArticlesPage({
               articles={toArticleData(currentArticles, law_category, law, famousArticles, true)}
               lawCategory={law_category}
               law={law}
+              currentPage={currentPage}
             />
           )}
 
@@ -327,6 +330,7 @@ export default async function LawArticlesPage({
                 articles={toArticleData(supplementary, law_category, law, famousArticles, true)}
                 lawCategory={law_category}
                 law={law}
+                currentPage={currentPage}
               />
             </div>
           )}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -106,3 +106,9 @@ export function safeSessionRemove(key: string): void {
     // ストレージ制限環境では無視
   }
 }
+
+// ============ Page Position ============
+
+export function getPageStorageKey(lawCategory: string, law: string): string {
+  return `osaka-kenpo-page-${lawCategory}-${law}`;
+}


### PR DESCRIPTION
## 関連 Issue
closes #45

## 変更内容
条文一覧ページでページネーションを使った際、条文詳細ページから「条文一覧へ」で戻ると1ページ目に戻ってしまう問題を修正。

### 仕組み
- **ArticleListWithEeyan**: 表示中のページ番号を `sessionStorage` に保存（`osaka-kenpo-page-{category}-{law}`）
- **ArticleClient**: 「条文一覧へ」リンクを `sessionStorage` から読み取ったページ番号付きURL（`?page=N`）に動的変更
- ページ1の場合は `sessionStorage` をクリアし、クエリパラメータなしのURLを使用

### 変更ファイル
- `ArticleListWithEeyan.tsx` — `currentPage` prop追加、sessionStorage保存ロジック
- `page.tsx` — 全ArticleListWithEeyan呼び出しに `currentPage` を渡す
- `ArticleClient.tsx` — 戻りリンクのhrefを動的に生成