### PR TITLE
fix: sumByPrefix の fetch に format=json を統一

### DIFF
--- a/src/app/components/LawCardWithEeyan.tsx
+++ b/src/app/components/LawCardWithEeyan.tsx
@@ -39,7 +39,7 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
     }
 
     const prefix = `osaka-kenpo-${category}-${lawName}-`;
-    fetch(`${NOSTALGIC_API_BASE}?action=sumByPrefix&prefix=${prefix}`)
+    fetch(`${NOSTALGIC_API_BASE}?action=sumByPrefix&prefix=${prefix}&format=json`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -74,7 +74,7 @@ export function LawCardWithEeyan({ law }: LawCardWithEeyanProps) {
     }
 
     const prefix = `osaka-kenpo-${category}-${lawName}-`;
-    fetch(`${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=${prefix}`)
+    fetch(`${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=${prefix}&format=json`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();

--- a/src/app/components/TotalViewCounter.tsx
+++ b/src/app/components/TotalViewCounter.tsx
@@ -28,7 +28,7 @@ export function TotalViewCounter() {
       }
 
       const res = await fetch(
-        `${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=osaka-kenpo-`
+        `${NOSTALGIC_COUNTER_API_BASE}?action=sumByPrefix&prefix=osaka-kenpo-&format=json`
       );
       if (!res.ok) {
         logger.warn('Total view counter API failed', { status: res.status });


### PR DESCRIPTION
## 背景

Nostalgic Counter/Like の集計を実機検証した際、`sumByPrefix` の呼び出し3箇所が `format=json` を付けておらず、個別 `get`（ArticleViewCounter / LikeButton）とは不統一だった。

- `TotalViewCounter.tsx`（トップ全体の閲覧合計）
- `LawCardWithEeyan.tsx`（法律ごとのええやん合計 / 閲覧合計）

現状は両形式とも動く（実機で `{"success":true,"total":N}` を確認）が、Nostalgic 側のデフォルト出力が変わると壊れうるため統一する。

## 検証で確認できたこと（集計の健全性）

実機 Playwright で全17法律を突き合わせ、**「法律カード表示 = その法律の条文 sumByPrefix 合計」が完全一致**を確認済み（刑法11 / 会社法6 / ドイツ基本法7 等）。トップ・法律ページは独自カウンターを持たず、条文ごとの個別カウンターを `sumByPrefix` で合算して表示しているだけ、という設計通りに動いている。

- 条文Counterは初訪問時に遅延作成（未訪問の条文は未作成＝正常）
- 即時反映は EeyanContext の revision 経由（最大30秒のsessionStorageキャッシュ遅延あり、許容範囲）

## 変更

3箇所の `sumByPrefix` fetch に `&format=json` を追加。型チェック通過（0 errors）。