### PR TITLE
Use Nostalgic batch read client

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -259,7 +259,7 @@ Content-Type: application/json
 }
 ```
 
-**制限**: 1回あたり最大 100 件（`NOSTALGIC_BATCH_LIMIT = 100`）。超過で 500 エラー。
+**制限**: 1回あたり最大 100 件（`NOSTALGIC_BATCH_LIMIT = 100`）。大阪憲法側では `batchGetNostalgicCounts()` が自動で分割する。
 
 **レスポンス**:
 
@@ -267,14 +267,22 @@ Content-Type: application/json
 {
   "success": true,
   "data": {
-    "osaka-kenpo-jp-minpou-1": { "total": 5 },
-    "osaka-kenpo-jp-minpou-2": { "total": 12 }
+    "osaka-kenpo-jp-minpou-1": {
+      "id": "osaka-kenpo-jp-minpou-1",
+      "total": 5,
+      "liked": false
+    },
+    "osaka-kenpo-jp-minpou-2": {
+      "id": "osaka-kenpo-jp-minpou-2",
+      "total": 12,
+      "liked": true
+    }
   }
 }
 ```
 
 **使用箇所**: `ArticleListWithEeyan`（法律ページの条文一覧）
-**分割**: 100件超の法律は自動的に100件ずつ分割リクエスト
+**分割**: `batchGetNostalgicCounts()` がページ全体で ID をまとめ、100件ずつ分割リクエスト
 
 #### 3.1.4 sumByPrefix — プレフィックスで合計取得
 
@@ -386,13 +394,27 @@ Content-Type: application/json
 {
   "success": true,
   "data": {
-    "osaka-kenpo-jp-minpou-1": { "total": 5 },
-    "osaka-kenpo-jp-minpou-2": { "total": 12 }
+    "osaka-kenpo-jp-minpou-1": {
+      "id": "osaka-kenpo-jp-minpou-1",
+      "total": 5,
+      "today": 1,
+      "yesterday": 0,
+      "week": 3,
+      "month": 5
+    },
+    "osaka-kenpo-jp-minpou-2": {
+      "id": "osaka-kenpo-jp-minpou-2",
+      "total": 12,
+      "today": 0,
+      "yesterday": 1,
+      "week": 4,
+      "month": 12
+    }
   }
 }
 ```
 
-**使用箇所**: 法律ページの条文一覧（各条文の閲覧数を一括表示）
+**使用箇所**: 法律ページの条文一覧（各条文の閲覧数を一括表示）。一覧では `increment` しない。
 
 ## 4. API 呼び出しパターン
 
@@ -407,7 +429,7 @@ Content-Type: application/json
 | ----------------------------- | --------------------------------------------------------------------------------------- |
 | LikeButton トグル             | Nostalgic toggle + D1 POST（`Promise.all`）                                             |
 | LikeButton マウント           | Nostalgic get + D1 GET（`Promise.all`）                                                 |
-| ArticleListWithEeyan マウント | Nostalgic batchGet (N回) + D1 GET（`Promise.all`）                                      |
+| ArticleListWithEeyan マウント | `batchGetNostalgicCounts()` 経由の Nostalgic batchGet + D1 GET（`Promise.all`）         |
 | 法律ページ サーバー           | `getArticles` + `getLawMetadata` + `getChapters` + `getFamousArticles`（`Promise.all`） |
 | 条文ページ サーバー           | `getArticle` + `getArticles` + `getLawMetadata`（`Promise.all`）                        |
 

--- a/docs/eeyan-spec.md
+++ b/docs/eeyan-spec.md
@@ -121,7 +121,7 @@ Content-Type: application/json
 }
 ```
 
-**制限**: 1回あたり最大100件。定数 `NOSTALGIC_BATCH_LIMIT = 100`（`src/lib/eeyan.ts`）。101件以上で500エラー。
+**制限**: 定数 `NOSTALGIC_BATCH_LIMIT = 100`（`src/lib/eeyan.ts`）ごとに `batchGetNostalgicCounts()` が安全に分割する。
 
 **レスポンス**:
 
@@ -129,8 +129,16 @@ Content-Type: application/json
 {
   "success": true,
   "data": {
-    "osaka-kenpo-jp-minpou-1": { "total": 5 },
-    "osaka-kenpo-jp-minpou-2": { "total": 12 }
+    "osaka-kenpo-jp-minpou-1": {
+      "id": "osaka-kenpo-jp-minpou-1",
+      "total": 5,
+      "liked": false
+    },
+    "osaka-kenpo-jp-minpou-2": {
+      "id": "osaka-kenpo-jp-minpou-2",
+      "total": 12,
+      "liked": true
+    }
   }
 }
 ```
@@ -553,7 +561,7 @@ sequenceDiagram
 
 **コンポーネント**: `ArticleListWithEeyan`（`src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx`）→ `ArticleListItem`（`src/app/components/ArticleListItem.tsx`）
 
-- Nostalgic API の `batchGet` で全条文のグローバルカウントを一括取得（100件ずつ分割）
+- Nostalgic API の `batchGet` で全条文のグローバルカウントを一括取得（`batchGetNostalgicCounts()` が分割）
 - D1 API の GET（モード1）で自分がいいねした条文IDセットを取得
 - 各条文カードの右下に `{likeCount} ええやん` をハートアイコン付きで表示
 

--- a/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
+++ b/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
@@ -9,6 +9,7 @@ import {
   getEeyanUserId,
   getNostalgicId,
 } from '@/lib/eeyan';
+import { batchGetNostalgicCounts } from '@/lib/nostalgicBatch';
 import { safeSessionSet, safeSessionRemove, getPageStorageKey } from '@/lib/storage';
 import { useEeyanRevision } from '@/app/context/EeyanContext';
 
@@ -46,68 +47,35 @@ export function ArticleListWithEeyan({
     const nostalgicIds = articles.map((a) => getNostalgicId(lawCategory, law, a.article));
     const prefix = `osaka-kenpo-${lawCategory}-${law}-`;
 
-    // Nostalgic APIの上限に合わせて分割
-    for (let i = 0; i < nostalgicIds.length; i += NOSTALGIC_BATCH_LIMIT) {
-      const batchIds = nostalgicIds.slice(i, i + NOSTALGIC_BATCH_LIMIT);
-
-      // Like batchGet
-      promises.push(
-        fetch(`${NOSTALGIC_API_BASE}?action=batchGet`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ids: batchIds }),
-        })
-          .then((res) => {
-            if (!res.ok) throw new Error(`batchGet failed: ${res.status}`);
-            return res.json() as Promise<{
-              success: boolean;
-              data: Record<string, { total: number }>;
-            }>;
-          })
-          .then((data) => {
-            if (data.success && data.data) {
-              const counts: Record<string, number> = {};
-              for (const [nostalgicId, info] of Object.entries(data.data)) {
-                if (nostalgicId.startsWith(prefix)) {
-                  const articleId = nostalgicId.slice(prefix.length);
-                  counts[articleId] = info.total;
-                }
-              }
-              setLikeCounts((prev) => ({ ...prev, ...counts }));
+    promises.push(
+      batchGetNostalgicCounts(NOSTALGIC_API_BASE, nostalgicIds, NOSTALGIC_BATCH_LIMIT)
+        .then((data) => {
+          const counts: Record<string, number> = {};
+          for (const [nostalgicId, info] of Object.entries(data)) {
+            if (nostalgicId.startsWith(prefix)) {
+              const articleId = nostalgicId.slice(prefix.length);
+              counts[articleId] = info.total;
             }
-          })
-          .catch(() => {})
-      );
-
-      // Counter batchGet（閲覧数）
-      promises.push(
-        fetch(`${NOSTALGIC_COUNTER_API_BASE}?action=batchGet`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ ids: batchIds }),
+          }
+          setLikeCounts((prev) => ({ ...prev, ...counts }));
         })
-          .then((res) => {
-            if (!res.ok) throw new Error(`counter batchGet failed: ${res.status}`);
-            return res.json() as Promise<{
-              success: boolean;
-              data: Record<string, { total: number }>;
-            }>;
-          })
-          .then((data) => {
-            if (data.success && data.data) {
-              const counts: Record<string, number> = {};
-              for (const [nostalgicId, info] of Object.entries(data.data)) {
-                if (nostalgicId.startsWith(prefix)) {
-                  const articleId = nostalgicId.slice(prefix.length);
-                  counts[articleId] = info.total;
-                }
-              }
-              setViewCounts((prev) => ({ ...prev, ...counts }));
+        .catch(() => {})
+    );
+
+    promises.push(
+      batchGetNostalgicCounts(NOSTALGIC_COUNTER_API_BASE, nostalgicIds, NOSTALGIC_BATCH_LIMIT)
+        .then((data) => {
+          const counts: Record<string, number> = {};
+          for (const [nostalgicId, info] of Object.entries(data)) {
+            if (nostalgicId.startsWith(prefix)) {
+              const articleId = nostalgicId.slice(prefix.length);
+              counts[articleId] = info.total;
             }
-          })
-          .catch(() => {})
-      );
-    }
+          }
+          setViewCounts((prev) => ({ ...prev, ...counts }));
+        })
+        .catch(() => {})
+    );
 
     // osaka-kenpo: 個人状態取得
     const userId = getEeyanUserId();

--- a/src/lib/eeyan.ts
+++ b/src/lib/eeyan.ts
@@ -8,7 +8,7 @@ export const NOSTALGIC_API_BASE = 'https://api.nostalgic.llll-ll.com/like';
 /** nostalgic Counter API ベースURL (Visit) */
 export const NOSTALGIC_COUNTER_API_BASE = 'https://api.nostalgic.llll-ll.com/visit';
 
-/** nostalgic batchGet の1回あたり上限（101件以上で500エラー） */
+/** nostalgic batchGet の1回あたり上限（大阪憲法側で安全に分割） */
 export const NOSTALGIC_BATCH_LIMIT = 100;
 
 /** nostalgic用のIDを生成 */

--- a/src/lib/nostalgicBatch.ts
+++ b/src/lib/nostalgicBatch.ts
@@ -1,0 +1,136 @@
+export interface NostalgicCountData {
+  total: number;
+  liked?: boolean;
+  today?: number;
+  yesterday?: number;
+  week?: number;
+  month?: number;
+}
+
+interface QueueEntry {
+  ids: Set<string>;
+  resolvers: Map<
+    string,
+    Array<{
+      resolve: (data: NostalgicCountData) => void;
+      reject: (error: unknown) => void;
+    }>
+  >;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const DEFAULT_BATCH_LIMIT = 100;
+const BATCH_DELAY_MS = 16;
+const CACHE_TTL_MS = 5000;
+
+const queues = new Map<string, QueueEntry>();
+const cache = new Map<string, { data: NostalgicCountData; expiresAt: number }>();
+
+function cacheKey(baseUrl: string, id: string): string {
+  return `${baseUrl}|${id}`;
+}
+
+function getCached(baseUrl: string, id: string): NostalgicCountData | null {
+  const key = cacheKey(baseUrl, id);
+  const cached = cache.get(key);
+  if (!cached || cached.expiresAt <= Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return cached.data;
+}
+
+function setCached(baseUrl: string, id: string, data: NostalgicCountData): void {
+  cache.set(cacheKey(baseUrl, id), {
+    data,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+}
+
+async function flushQueue(baseUrl: string, batchLimit: number): Promise<void> {
+  const queue = queues.get(baseUrl);
+  if (!queue) return;
+  queues.delete(baseUrl);
+
+  const ids = [...queue.ids];
+  for (let i = 0; i < ids.length; i += batchLimit) {
+    const chunk = ids.slice(i, i + batchLimit);
+
+    try {
+      const response = await fetch(`${baseUrl}?action=batchGet`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: chunk }),
+      });
+      if (!response.ok) {
+        throw new Error(`batchGet failed: ${response.status}`);
+      }
+
+      const json = (await response.json()) as {
+        success: boolean;
+        data?: Record<string, NostalgicCountData>;
+        error?: string;
+      };
+      if (!json.success || !json.data) {
+        throw new Error(json.error || 'batchGet failed');
+      }
+
+      for (const id of chunk) {
+        const data = json.data[id] || { total: 0 };
+        setCached(baseUrl, id, data);
+        for (const resolver of queue.resolvers.get(id) || []) {
+          resolver.resolve(data);
+        }
+      }
+    } catch (error) {
+      for (const id of chunk) {
+        for (const resolver of queue.resolvers.get(id) || []) {
+          resolver.reject(error);
+        }
+      }
+    }
+  }
+}
+
+function requestNostalgicCount(
+  baseUrl: string,
+  id: string,
+  batchLimit: number
+): Promise<NostalgicCountData> {
+  const cached = getCached(baseUrl, id);
+  if (cached) {
+    return Promise.resolve(cached);
+  }
+
+  return new Promise((resolve, reject) => {
+    let queue = queues.get(baseUrl);
+    if (!queue) {
+      queue = { ids: new Set(), resolvers: new Map(), timer: null };
+      queues.set(baseUrl, queue);
+    }
+
+    queue.ids.add(id);
+    if (!queue.resolvers.has(id)) {
+      queue.resolvers.set(id, []);
+    }
+    queue.resolvers.get(id)?.push({ resolve, reject });
+
+    if (!queue.timer) {
+      queue.timer = setTimeout(() => {
+        void flushQueue(baseUrl, batchLimit);
+      }, BATCH_DELAY_MS);
+    }
+  });
+}
+
+export async function batchGetNostalgicCounts(
+  baseUrl: string,
+  ids: string[],
+  batchLimit = DEFAULT_BATCH_LIMIT
+): Promise<Record<string, NostalgicCountData>> {
+  const uniqueIds = [...new Set(ids)];
+  const entries = await Promise.all(
+    uniqueIds.map(async (id) => [id, await requestNostalgicCount(baseUrl, id, batchLimit)] as const)
+  );
+  return Object.fromEntries(entries);
+}


### PR DESCRIPTION
## 関連
Depends on kako-jun/nostalgic#5

## 変更内容
- 条文一覧の Like / Counter batchGet を共通 client に移行
- `batchGetNostalgicCounts()` でページ全体の ID を集約し、上限ごとに分割
- Nostalgic の新しい batchGet 正規レスポンスに docs を更新
- 条文一覧は read-only のまま維持し、個別条文ページの increment は変更なし

## 注意
- Nostalgic API の batchGet 新レスポンスがデプロイされた後に merge する

## 検証
- npm run typecheck
