### PR TITLE
fix(eeyan): batch client review follow-up（force バイパス）

### DIFF
--- a/docs/eeyan-spec.md
+++ b/docs/eeyan-spec.md
@@ -123,6 +123,8 @@ Content-Type: application/json
 
 **制限**: 定数 `NOSTALGIC_BATCH_LIMIT = 100`（`src/lib/eeyan.ts`）ごとに `batchGetNostalgicCounts()` が安全に分割する。
 
+**集約とキャッシュ**: `batchGetNostalgicCounts()`（`src/lib/nostalgicBatch.ts`）はページ全体の id を 16ms デバウンスで束ね dedupe し、結果を baseUrl+id 単位で 5 秒メモリキャッシュする。第4引数 `force=true` でキャッシュをバイパスでき、**ええやん操作直後の再取得（`eeyanRevision` 経路）は force 指定で最新カウントを必ず取得する**（初回マウント・`visibilitychange` 経路はキャッシュ可）。
+
 **レスポンス**:
 
 ```json

--- a/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
+++ b/src/app/law/[law_category]/[law]/components/ArticleListWithEeyan.tsx
@@ -40,70 +40,81 @@ export function ArticleListWithEeyan({
   const [userLikes, setUserLikes] = useState<Set<string>>(new Set());
   const eeyanRevision = useEeyanRevision();
 
-  const fetchEeyanData = useCallback(async () => {
-    const promises: Promise<void>[] = [];
+  const fetchEeyanData = useCallback(
+    async (force = false) => {
+      const promises: Promise<void>[] = [];
 
-    // nostalgic batchGet で全体カウント取得
-    const nostalgicIds = articles.map((a) => getNostalgicId(lawCategory, law, a.article));
-    const prefix = `osaka-kenpo-${lawCategory}-${law}-`;
+      // nostalgic batchGet で全体カウント取得
+      const nostalgicIds = articles.map((a) => getNostalgicId(lawCategory, law, a.article));
+      // batchGet は渡した id しか返さないため startsWith(prefix) は通常常に真。
+      // 想定外の id を取り違えない防御 + articleId 復元（slice）を兼ねる。
+      const prefix = `osaka-kenpo-${lawCategory}-${law}-`;
 
-    promises.push(
-      batchGetNostalgicCounts(NOSTALGIC_API_BASE, nostalgicIds, NOSTALGIC_BATCH_LIMIT)
-        .then((data) => {
-          const counts: Record<string, number> = {};
-          for (const [nostalgicId, info] of Object.entries(data)) {
-            if (nostalgicId.startsWith(prefix)) {
-              const articleId = nostalgicId.slice(prefix.length);
-              counts[articleId] = info.total;
-            }
-          }
-          setLikeCounts((prev) => ({ ...prev, ...counts }));
-        })
-        .catch(() => {})
-    );
-
-    promises.push(
-      batchGetNostalgicCounts(NOSTALGIC_COUNTER_API_BASE, nostalgicIds, NOSTALGIC_BATCH_LIMIT)
-        .then((data) => {
-          const counts: Record<string, number> = {};
-          for (const [nostalgicId, info] of Object.entries(data)) {
-            if (nostalgicId.startsWith(prefix)) {
-              const articleId = nostalgicId.slice(prefix.length);
-              counts[articleId] = info.total;
-            }
-          }
-          setViewCounts((prev) => ({ ...prev, ...counts }));
-        })
-        .catch(() => {})
-    );
-
-    // osaka-kenpo: 個人状態取得
-    const userId = getEeyanUserId();
-    if (userId) {
       promises.push(
-        fetch(`/api/eeyan?userId=${userId}&category=${lawCategory}&lawName=${law}`)
-          .then((res) => res.json() as Promise<{ success: boolean; likes: string[] }>)
+        batchGetNostalgicCounts(NOSTALGIC_API_BASE, nostalgicIds, NOSTALGIC_BATCH_LIMIT, force)
           .then((data) => {
-            if (data.success) {
-              setUserLikes(new Set(data.likes));
+            const counts: Record<string, number> = {};
+            for (const [nostalgicId, info] of Object.entries(data)) {
+              if (nostalgicId.startsWith(prefix)) {
+                const articleId = nostalgicId.slice(prefix.length);
+                counts[articleId] = info.total;
+              }
             }
+            setLikeCounts((prev) => ({ ...prev, ...counts }));
           })
           .catch(() => {})
       );
-    }
 
-    await Promise.all(promises);
-  }, [articles, lawCategory, law]);
+      promises.push(
+        batchGetNostalgicCounts(
+          NOSTALGIC_COUNTER_API_BASE,
+          nostalgicIds,
+          NOSTALGIC_BATCH_LIMIT,
+          force
+        )
+          .then((data) => {
+            const counts: Record<string, number> = {};
+            for (const [nostalgicId, info] of Object.entries(data)) {
+              if (nostalgicId.startsWith(prefix)) {
+                const articleId = nostalgicId.slice(prefix.length);
+                counts[articleId] = info.total;
+              }
+            }
+            setViewCounts((prev) => ({ ...prev, ...counts }));
+          })
+          .catch(() => {})
+      );
 
-  // 初回マウント時 + props変更時に取得
+      // osaka-kenpo: 個人状態取得
+      const userId = getEeyanUserId();
+      if (userId) {
+        promises.push(
+          fetch(`/api/eeyan?userId=${userId}&category=${lawCategory}&lawName=${law}`)
+            .then((res) => res.json() as Promise<{ success: boolean; likes: string[] }>)
+            .then((data) => {
+              if (data.success) {
+                setUserLikes(new Set(data.likes));
+              }
+            })
+            .catch(() => {})
+        );
+      }
+
+      await Promise.all(promises);
+    },
+    [articles, lawCategory, law]
+  );
+
+  // 初回マウント時 + props変更時に取得（キャッシュ可）
   useEffect(() => {
     fetchEeyanData();
   }, [fetchEeyanData]);
 
-  // ええやん操作後に再取得（別ページの LikeButton からの通知）
+  // ええやん操作後に再取得（別ページの LikeButton からの通知）。
+  // 直後の最新カウントが要るのでキャッシュをバイパス（force=true）する。
   useEffect(() => {
     if (eeyanRevision === 0) return; // 初回マウント時はスキップ
-    fetchEeyanData();
+    fetchEeyanData(true);
   }, [eeyanRevision, fetchEeyanData]);
 
   // ページが再表示された時にデータを再取得（デバウンス付き）

--- a/src/lib/nostalgicBatch.ts
+++ b/src/lib/nostalgicBatch.ts
@@ -1,3 +1,6 @@
+// Nostalgic API の batchGet 正規レスポンス（visit/like 共通の上位集合）。
+// 現状 osaka-kenpo は `total` のみ消費する（liked は /api/eeyan の D1 経路で別取得、
+// today/yesterday/week/month は条文詳細ページ用に予約）。API 形と一致させるため全フィールド保持。
 export interface NostalgicCountData {
   total: number;
   liked?: boolean;
@@ -19,6 +22,8 @@ interface QueueEntry {
   timer: ReturnType<typeof setTimeout> | null;
 }
 
+// 呼び出し側（osaka-kenpo は eeyan.ts の NOSTALGIC_BATCH_LIMIT）が batchLimit を渡すのが正。
+// この定数は引数省略時の汎用フォールバック。Nostalgic API は 101 件以上で 500 を返す。
 const DEFAULT_BATCH_LIMIT = 100;
 const BATCH_DELAY_MS = 16;
 const CACHE_TTL_MS = 5000;
@@ -83,6 +88,7 @@ async function flushQueue(baseUrl: string, batchLimit: number): Promise<void> {
         }
       }
     } catch (error) {
+      // 失敗分はキャッシュしない（負のキャッシュは持たない）。呼び出し側が次回再取得できるようにする。
       for (const id of chunk) {
         for (const resolver of queue.resolvers.get(id) || []) {
           resolver.reject(error);
@@ -95,11 +101,16 @@ async function flushQueue(baseUrl: string, batchLimit: number): Promise<void> {
 function requestNostalgicCount(
   baseUrl: string,
   id: string,
-  batchLimit: number
+  batchLimit: number,
+  force: boolean
 ): Promise<NostalgicCountData> {
-  const cached = getCached(baseUrl, id);
-  if (cached) {
-    return Promise.resolve(cached);
+  // force=false のときだけ 5 秒キャッシュを使う。ええやん操作直後の再取得は
+  // force=true で必ずネットワークから最新カウントを取り、stale 表示を防ぐ。
+  if (!force) {
+    const cached = getCached(baseUrl, id);
+    if (cached) {
+      return Promise.resolve(cached);
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -126,11 +137,14 @@ function requestNostalgicCount(
 export async function batchGetNostalgicCounts(
   baseUrl: string,
   ids: string[],
-  batchLimit = DEFAULT_BATCH_LIMIT
+  batchLimit = DEFAULT_BATCH_LIMIT,
+  force = false
 ): Promise<Record<string, NostalgicCountData>> {
   const uniqueIds = [...new Set(ids)];
   const entries = await Promise.all(
-    uniqueIds.map(async (id) => [id, await requestNostalgicCount(baseUrl, id, batchLimit)] as const)
+    uniqueIds.map(
+      async (id) => [id, await requestNostalgicCount(baseUrl, id, batchLimit, force)] as const
+    )
   );
   return Object.fromEntries(entries);
 }


### PR DESCRIPTION
## 関連
PR #52 の独立レビュー（事後）指摘対応。Refs #53

## 背景
PR #52（Nostalgic batch read client 移行）を独立サブエージェントレビューに通したところ、must は無かったが should/nit が出たので全件対応。

## 変更
- **should（実バグ性）**: ええやん操作直後の再取得（`eeyanRevision` 経路）で `batchGetNostalgicCounts` の 5 秒メモリキャッシュが stale 値を返し、いいねカウントが最大 5 秒更新されない。`batchGetNostalgicCounts(..., force)` 引数を追加し、`eeyanRevision` 経路を `force=true` でキャッシュバイパスに。初回マウント・visibilitychange はキャッシュ可のまま。
- **should/nit（コメント明記）**: prefix フィルタの防御意図、`liked`/期間フィールドは予約（現状 total のみ消費）、負のキャッシュ非保持、`DEFAULT_BATCH_LIMIT` はフォールバックである旨。
- **docs**: `docs/eeyan-spec.md` 2.1.3 に集約・キャッシュ・force の挙動を追記。
- **#6 テスト基盤不在**: スコープ過大のため #53 に分離起票。

## 検証
- `npx tsc --noEmit` clean
- `npx eslint` 対象2ファイル clean