### PR TITLE
perf: 条文ナビを軽量クエリ化して Worker の CPU/メモリ超過(Error 1102)を解消

### DIFF
--- a/src/app/law/[law_category]/[law]/[article]/page.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
-import { getArticle, getArticles, getLawMetadata, type ArticleRow } from '@/lib/db';
+import { getArticle, getArticleNavList, getLawMetadata, type ArticleNavRow } from '@/lib/db';
 import { ArticleClient } from './ArticleClient';
 import { lawsMetadata } from '@/data/lawsMetadata';
-import { formatArticleNumber } from '@/lib/utils';
+import { extractFirstParagraphFromHead, formatArticleNumber } from '@/lib/utils';
 import buildDateJson from '@/data/build-date.json';
 
 export const runtime = 'edge';
@@ -80,7 +80,7 @@ export default async function ArticlePage({
     // D1から並行でデータ取得
     [articleRow, allArticlesRows, lawMetadata] = await Promise.all([
       getArticle(law_category, law, article),
-      getArticles(law_category, law),
+      getArticleNavList(law_category, law),
       getLawMetadata(law_category, law),
     ]);
   } catch (error) {
@@ -156,17 +156,13 @@ export default async function ArticlePage({
   };
 
   // 全条文リストをクライアント用に変換
-  const allArticles = allArticlesRows.map((a: ArticleRow) => {
+  const allArticles = allArticlesRows.map((a: ArticleNavRow) => {
     let originalTextExcerpt: string | undefined;
-    if (!a.title && a.original_text) {
-      try {
-        const parsed = JSON.parse(a.original_text);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          const firstLine = parsed[0].replace(/\s+/g, ' ').trim();
-          originalTextExcerpt = firstLine.length > 12 ? firstLine.slice(0, 12) + '...' : firstLine;
-        }
-      } catch {
-        // ignore parse errors
+    if (!a.title && a.original_text_head) {
+      const parsed = extractFirstParagraphFromHead(a.original_text_head);
+      if (parsed) {
+        const firstLine = parsed.replace(/\s+/g, ' ').trim();
+        originalTextExcerpt = firstLine.length > 12 ? firstLine.slice(0, 12) + '...' : firstLine;
       }
     }
     return {

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next';
 import {
-  getArticles,
+  getArticleNavList,
   getLawMetadata,
   getChapters,
   getFamousArticles,
-  type ArticleRow,
+  type ArticleNavRow,
   type ChapterRow,
 } from '@/lib/db';
 import { ShareButton } from '@/app/components/ShareButton';
@@ -12,7 +12,7 @@ import { ScrollAwareBackLink } from '@/app/components/navigation/ScrollAwareBack
 import { ArticleListWithEeyan } from './components/ArticleListWithEeyan';
 import { Pagination } from '@/app/components/Pagination';
 import { lawsMetadata } from '@/data/lawsMetadata';
-import { getArticleSortKey } from '@/lib/utils';
+import { extractFirstParagraphFromHead, getArticleSortKey } from '@/lib/utils';
 
 export const runtime = 'edge';
 
@@ -48,18 +48,9 @@ export async function generateMetadata({
 
 const ARTICLES_PER_PAGE = 100;
 
-// 原文JSONから最初の段落を取得
-function getFirstParagraph(originalTextJson: string | null | undefined): string {
-  if (!originalTextJson) return '';
-  try {
-    const parsed = JSON.parse(originalTextJson);
-    if (Array.isArray(parsed) && parsed.length > 0) {
-      return String(parsed[0]);
-    }
-  } catch {
-    // パース失敗時は空文字
-  }
-  return '';
+// 原文JSON断片（先頭100文字）から最初の段落を取得
+function getFirstParagraph(originalTextHead: string | null | undefined): string {
+  return extractFirstParagraphFromHead(originalTextHead);
 }
 
 // 条文番号から基本番号を抽出（1-2 → 1, 876-5 → 876）
@@ -77,9 +68,9 @@ function getBaseArticleNumber(article: string): number {
 }
 
 // 条文を分類
-function classifyArticles(articles: ArticleRow[]) {
-  const normal: ArticleRow[] = [];
-  const supplementary: ArticleRow[] = [];
+function classifyArticles(articles: ArticleNavRow[]) {
+  const normal: ArticleNavRow[] = [];
+  const supplementary: ArticleNavRow[] = [];
 
   for (const article of articles) {
     const articleStr = String(article.article);
@@ -103,7 +94,7 @@ function classifyArticles(articles: ArticleRow[]) {
 
 // 条文番号の範囲でページを計算
 function getArticlePageRanges(
-  articles: ArticleRow[]
+  articles: ArticleNavRow[]
 ): { start: number; end: number; label: string }[] {
   if (articles.length === 0) return [];
 
@@ -131,16 +122,20 @@ function getArticlePageRanges(
 }
 
 // 指定された条文番号範囲の条文をフィルタ
-function filterArticlesByRange(articles: ArticleRow[], start: number, end: number): ArticleRow[] {
+function filterArticlesByRange(
+  articles: ArticleNavRow[],
+  start: number,
+  end: number
+): ArticleNavRow[] {
   return articles.filter((article) => {
     const baseNum = getBaseArticleNumber(String(article.article));
     return baseNum >= start && baseNum <= end;
   });
 }
 
-// ArticleRow[] を ArticleListWithEeyan 用のデータに変換
+// ArticleNavRow[] を ArticleListWithEeyan 用のデータに変換
 function toArticleData(
-  articles: ArticleRow[],
+  articles: ArticleNavRow[],
   law_category: string,
   law: string,
   famousArticles: Record<string, string>,
@@ -152,7 +147,7 @@ function toArticleData(
     href: `/law/${law_category}/${law}/${article.article}`,
     famousArticleBadge: famousArticles?.[article.article.toString()] || null,
     isDeleted: article.is_deleted === 1,
-    originalText: includeOriginalText ? getFirstParagraph(article.original_text) : undefined,
+    originalText: includeOriginalText ? getFirstParagraph(article.original_text_head) : undefined,
   }));
 }
 
@@ -170,7 +165,7 @@ export default async function LawArticlesPage({
 
   // D1から並行でデータ取得
   const [articles, lawMetadata, chapters, famousArticles] = await Promise.all([
-    getArticles(law_category, law),
+    getArticleNavList(law_category, law),
     getLawMetadata(law_category, law),
     getChapters(law_category, law),
     getFamousArticles(law_category, law),
@@ -195,8 +190,9 @@ export default async function LawArticlesPage({
 
   // 章でグループ化（章構成がある法律用）
   const hasChapters = chapters && chapters.length > 0;
-  const groupedArticles: { [chapterKey: string]: { chapter: ChapterRow; articles: ArticleRow[] } } =
-    {};
+  const groupedArticles: {
+    [chapterKey: string]: { chapter: ChapterRow; articles: ArticleNavRow[] };
+  } = {};
 
   if (hasChapters) {
     for (const chapter of chapters) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -25,6 +25,14 @@ export interface ArticleRow {
   commentary_osaka?: string | null;
 }
 
+export interface ArticleNavRow {
+  article: string;
+  title: string | null;
+  title_osaka: string | null;
+  is_deleted: number;
+  original_text_head: string | null;
+}
+
 export interface ChapterRow {
   chapter: string;
   title: string;
@@ -73,12 +81,16 @@ export async function getLawsByCategory(category: string) {
   return result.results;
 }
 
-// 法律の条文一覧を取得
-export async function getArticles(category: string, lawName: string): Promise<ArticleRow[]> {
+// ナビ/一覧用の軽量取得（原文はフルではなく先頭100文字だけ）
+export async function getArticleNavList(
+  category: string,
+  lawName: string
+): Promise<ArticleNavRow[]> {
   const db = getDB();
   const result = await db
     .prepare(
-      `SELECT article, title, title_osaka, is_deleted, original_text
+      `SELECT article, title, title_osaka, is_deleted,
+              substr(original_text, 1, 100) AS original_text_head
        FROM articles
        WHERE category = ? AND law_name = ?
        ORDER BY
@@ -86,7 +98,7 @@ export async function getArticles(category: string, lawName: string): Promise<Ar
          article`
     )
     .bind(category, lawName)
-    .all<ArticleRow>();
+    .all<ArticleNavRow>();
   return result.results;
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -99,21 +99,63 @@ export function getExcerpt(text: string, maxLength: number = 50): string {
  */
 export function extractFirstParagraphFromHead(head: string | null | undefined): string {
   if (!head) return '';
-  // 先頭の `[`・空白・開き `"` を剥がす
+  // 先頭の `[`・空白・開き `"` を剥がして第一要素の本文開始位置へ
   const m = /^\s*\[\s*"/.exec(head);
   if (!m) return '';
-  let body = head.slice(m[0].length);
-  // 最初の「未エスケープの "」で切る（無ければ末尾まで＝断片のまま）
-  const q = /(?<!\\)"/.exec(body);
-  if (q) body = body.slice(0, q.index);
-  // JSON文字列エスケープの最小復元
-  body = body
-    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
-    .replace(/\\n/g, ' ')
-    .replace(/\\t/g, ' ')
-    .replace(/\\"/g, '"')
-    .replace(/\\\\/g, '\\');
-  return body;
+  let i = m[0].length;
+  let out = '';
+  while (i < head.length) {
+    const ch = head[i];
+    if (ch === '"') break; // 未エスケープの閉じ引用 = 第一要素の終端
+    if (ch === '\\') {
+      const next = head[i + 1];
+      if (next === undefined) break; // 断片末尾でエスケープが切れている
+      switch (next) {
+        case 'n':
+          out += '\n';
+          break;
+        case 't':
+          out += '\t';
+          break;
+        case 'r':
+          out += '\r';
+          break;
+        case 'b':
+          out += '\b';
+          break;
+        case 'f':
+          out += '\f';
+          break;
+        case '"':
+          out += '"';
+          break;
+        case '\\':
+          out += '\\';
+          break;
+        case '/':
+          out += '/';
+          break;
+        case 'u': {
+          const hex = head.slice(i + 2, i + 6);
+          if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+            out += String.fromCharCode(parseInt(hex, 16));
+            i += 6;
+            continue;
+          }
+          out += next; // 不完全な \u はそのまま
+          break;
+        }
+        default:
+          out += next;
+          break;
+      }
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,6 +93,30 @@ export function getExcerpt(text: string, maxLength: number = 50): string {
 }
 
 /**
+ * JSON配列文字列の先頭断片（substr で切れている可能性あり）から
+ * 最初の要素（先頭段落）の文字列を復元する。切断されていても壊れない。
+ * 後処理（whitespace正規化・trim・切り詰め）は呼び出し側に委ねる。
+ */
+export function extractFirstParagraphFromHead(head: string | null | undefined): string {
+  if (!head) return '';
+  // 先頭の `[`・空白・開き `"` を剥がす
+  const m = /^\s*\[\s*"/.exec(head);
+  if (!m) return '';
+  let body = head.slice(m[0].length);
+  // 最初の「未エスケープの "」で切る（無ければ末尾まで＝断片のまま）
+  const q = /(?<!\\)"/.exec(body);
+  if (q) body = body.slice(0, q.index);
+  // JSON文字列エスケープの最小復元
+  body = body
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\n/g, ' ')
+    .replace(/\\t/g, ' ')
+    .replace(/\\"/g, '"')
+    .replace(/\\\\/g, '\\');
+  return body;
+}
+
+/**
  * 条文番号のソートキーを返す（枝番・附則・改正対応）
  */
 export function getArticleSortKey(article: string): number {


### PR DESCRIPTION
## 関連 Issue
closes #55

## 症状
宣伝後、巨大法（民法・刑法・商法・刑事訴訟法）のページで Cloudflare **Error 1102 (Worker exceeded resource limits)** が断続的に発生していた（ユーザーには 503）。

## 真因
`getArticles()` が「その法律の全条文を `original_text`（原文フルテキスト）込み・LIMIT なし」で取得しており、これが**一覧ページと単一条文ページの両方**で呼ばれていた。巨大法（民法 ~1050条）ではMB級の転送＋全件 `JSON.parse` になり、1リクエストが Worker の CPU/メモリ上限スレスレに。Workers は isolate をリクエスト間で共有しメモリ上限は isolate 単位のため、宣伝で同時アクセスが増えると合算超過し 1102 が頻発した。

原文フルテキストが必要なのは「見出し(title)の無い条文のフォールバック抜粋」だけ（ポップアップ12字／一覧50字）。前後ナビ・ジャンプポップアップは全条文の「番号・順序・見出し」のみ必要。

## 変更内容
- `src/lib/db.ts`: `getArticles` を軽量クエリ `getArticleNavList` に置換。原文は `substr(original_text, 1, 100) AS original_text_head` だけ取得。`ORDER BY` は旧クエリと完全一致（prev/next の順序を保持）。型 `ArticleNavRow` を追加。
- `src/lib/utils.ts`: 耐切断パーサ `extractFirstParagraphFromHead` を追加。`substr` で切れた JSON 配列断片から先頭段落を**単一パススキャナ**で復元（`JSON.parse` 等価・例外安全）。
- 一覧ページ / 単一条文ページ: `getArticleNavList` に差し替え、抜粋を新ヘルパー経由に。`getArticles` は未使用になったため削除。
- 触っていない: `getArticle`(単数, 条文本体の原文表示)・`api/eeyan/route.ts`（件数有界でスコープ外）。

## 検証
- 新ヘルパーを `JSON.parse(full)[0]` と node で突き合わせ、バックスラッシュ/タブ/改行/unicode を含む正しいJSON全ケースで12字・50字抜粋とも一致（退行なし）。
- 独立レビュー2巡: 初回 Approve（エスケープ復元の2バグ指摘）→ 単一パススキャナで根治 → 再レビュー Approve（must/should 0）。
- `npm run typecheck` / `npm run lint` グリーン。
- ⚠️ 実機での 1102 解消確認（民法・刑法ページの連続アクセス）はデプロイ後に実施予定。
