### PR TITLE
test: ポップアップ抜粋整形を純関数navExcerptFromHeadに切り出してテスト

### DIFF
--- a/src/app/law/[law_category]/[law]/[article]/page.tsx
+++ b/src/app/law/[law_category]/[law]/[article]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { getArticle, getArticleNavList, getLawMetadata, type ArticleNavRow } from '@/lib/db';
 import { ArticleClient } from './ArticleClient';
 import { lawsMetadata } from '@/data/lawsMetadata';
-import { extractFirstParagraphFromHead, formatArticleNumber } from '@/lib/utils';
+import { navExcerptFromHead, formatArticleNumber } from '@/lib/utils';
 import buildDateJson from '@/data/build-date.json';
 
 export const runtime = 'edge';
@@ -156,22 +156,12 @@ export default async function ArticlePage({
   };
 
   // 全条文リストをクライアント用に変換
-  const allArticles = allArticlesRows.map((a: ArticleNavRow) => {
-    let originalTextExcerpt: string | undefined;
-    if (!a.title && a.original_text_head) {
-      const parsed = extractFirstParagraphFromHead(a.original_text_head);
-      if (parsed) {
-        const firstLine = parsed.replace(/\s+/g, ' ').trim();
-        originalTextExcerpt = firstLine.length > 12 ? firstLine.slice(0, 12) + '...' : firstLine;
-      }
-    }
-    return {
-      article: a.article,
-      title: a.title || '',
-      titleOsaka: a.title_osaka || undefined,
-      originalText: originalTextExcerpt,
-    };
-  });
+  const allArticles = allArticlesRows.map((a: ArticleNavRow) => ({
+    article: a.article,
+    title: a.title || '',
+    titleOsaka: a.title_osaka || undefined,
+    originalText: (!a.title ? navExcerptFromHead(a.original_text_head) : '') || undefined,
+  }));
 
   // JSON-LD: このサイトの独自価値は「大阪弁での解説」。原文(e-Gov重複)ではなく
   // 大阪弁訳・大阪弁解説を articleBody に据えて、独自コンテンツとして宣言する。

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -208,6 +208,11 @@ describe('navExcerptFromHead', () => {
     expect(navExcerptFromHead('foo')).toBe('');
   });
 
+  it('空白のみの先頭段落は空文字を返す（trim後に空）', () => {
+    expect(navExcerptFromHead('["   "]')).toBe('');
+    expect(navExcerptFromHead('["\\n\\t "]')).toBe('');
+  });
+
   it('substr で切断された断片（閉じ " に届かない長い head）でも例外なく抜粋を返す', () => {
     const full = JSON.stringify([
       'とても長い第一段落のテキストがここに続いていきます、まだまだ終わりません',

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   extractFirstParagraphFromHead,
+  navExcerptFromHead,
   getArticleSortKey,
   getExcerpt,
   formatArticleNumber,
@@ -164,6 +165,64 @@ describe('getExcerpt', () => {
 
   it('空文字入力は空文字を返す', () => {
     expect(getExcerpt('')).toBe('');
+  });
+});
+
+describe('navExcerptFromHead', () => {
+  it('12文字以内の先頭段落はそのまま返す', () => {
+    const head = JSON.stringify(['短い条文']);
+    expect(navExcerptFromHead(head)).toBe('短い条文');
+  });
+
+  it('ちょうど12文字の先頭段落は切らずにそのまま返す', () => {
+    const text = 'あいうえおかきくけこさし'; // 12文字
+    expect(text.length).toBe(12);
+    expect(navExcerptFromHead(JSON.stringify([text]))).toBe(text);
+  });
+
+  it('12文字超は slice(0,12) + "..." に切る（13文字→末尾..., 長さ15）', () => {
+    const text = 'あいうえおかきくけこさしす'; // 13文字
+    expect(text.length).toBe(13);
+    const result = navExcerptFromHead(JSON.stringify([text]));
+    expect(result).toBe('あいうえおかきくけこさし' + '...');
+    expect(result.endsWith('...')).toBe(true);
+    expect(result.length).toBe(15);
+  });
+
+  it('明示した maxLength を尊重する（maxLength=5）', () => {
+    const head = JSON.stringify(['abcdefgh']);
+    expect(navExcerptFromHead(head, 5)).toBe('abcde...');
+  });
+
+  it('段落内の改行・タブ・連続空白は単一スペースに正規化してから切る', () => {
+    const head = JSON.stringify(['あ\nい\tう  え']);
+    expect(navExcerptFromHead(head)).toBe('あ い う え');
+  });
+
+  it('null / undefined / 空文字 / [] / [ ] / 非配列文字列はすべて空文字を返す', () => {
+    expect(navExcerptFromHead(null)).toBe('');
+    expect(navExcerptFromHead(undefined)).toBe('');
+    expect(navExcerptFromHead('')).toBe('');
+    expect(navExcerptFromHead('[]')).toBe('');
+    expect(navExcerptFromHead('[ ]')).toBe('');
+    expect(navExcerptFromHead('foo')).toBe('');
+  });
+
+  it('substr で切断された断片（閉じ " に届かない長い head）でも例外なく抜粋を返す', () => {
+    const full = JSON.stringify([
+      'とても長い第一段落のテキストがここに続いていきます、まだまだ終わりません',
+    ]);
+    const head = full.slice(0, 20); // 閉じ引用まで到達しない長さで切る
+    let result: string;
+    expect(() => {
+      result = navExcerptFromHead(head);
+    }).not.toThrow();
+    result = navExcerptFromHead(head);
+    expect(result).toBe('とても長い第一段落のテキ...');
+    expect(result.length).toBe(15);
+    // 切断していない完全版と接頭辞関係になっている
+    const complete = extractFirstParagraphFromHead(full).replace(/\s+/g, ' ').trim();
+    expect(complete.startsWith(result.slice(0, 12))).toBe(true);
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -158,6 +158,14 @@ export function extractFirstParagraphFromHead(head: string | null | undefined): 
   return out;
 }
 
+/** ナビ用: 原文headから見出し無し条文のフォールバック抜粋（先頭段落をN字に切る） */
+export function navExcerptFromHead(head: string | null | undefined, maxLength = 12): string {
+  const parsed = extractFirstParagraphFromHead(head);
+  if (!parsed) return '';
+  const firstLine = parsed.replace(/\s+/g, ' ').trim();
+  return firstLine.length > maxLength ? firstLine.slice(0, maxLength) + '...' : firstLine;
+}
+
 /**
  * 条文番号のソートキーを返す（枝番・附則・改正対応）
  */


### PR DESCRIPTION
## 関連 Issue
closes #59

## 背景
#57 で vitest を整備したが、条文ジャンプポップアップ（`ArticlePopup`）のフォールバック抜粋整形だけが RSC コンポーネント内インラインでテストの穴になっていた。

## 変更
- `src/lib/utils.ts`: ポップアップの抜粋整形を純関数 `navExcerptFromHead(head, maxLength=12)` に切り出し（先頭段落を取り、空白正規化して N 字で `…` 切り）。stripHtml は足さず**旧インラインと完全一致**。
- `[article]/page.tsx`: インライン整形を `navExcerptFromHead` 呼び出しに置換。`originalText: (!a.title ? navExcerptFromHead(a.original_text_head) : '') || undefined` でセマンティクス（titled→undefined / 抜粋空→undefined / 抜粋あり→文字列）を保持。
- `src/lib/utils.test.ts`: `navExcerptFromHead` のテスト9件追加（12字境界・空白正規化・null/空/非配列・空白のみ段落・substr断片・maxLength）。

## 検証
- `npm run test`: 41/41 パス。`npm run typecheck`/`lint` グリーン。
- 独立レビュー Approve。旧↔新のセマンティクス等価を真理値表で検証（唯一の差「空白のみ段落で ''→undefined」は唯一の消費先 `ArticlePopup` が truthy 判定のため表示同一＝非観測、テストで契約固定）。
- 表示挙動は完全不変。デプロイ後に条文ページのポップアップを目視確認予定。
