### PR TITLE
docs+refactor: セッションレビュー追従（docs同期・抜粋整形3面統一・passthrough削除）

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -425,13 +425,13 @@ Content-Type: application/json
 
 ### 4.2 並行呼び出し
 
-| 場面                          | 並行呼び出し内容                                                                        |
-| ----------------------------- | --------------------------------------------------------------------------------------- |
-| LikeButton トグル             | Nostalgic toggle + D1 POST（`Promise.all`）                                             |
-| LikeButton マウント           | Nostalgic get + D1 GET（`Promise.all`）                                                 |
-| ArticleListWithEeyan マウント | `batchGetNostalgicCounts()` 経由の Nostalgic batchGet + D1 GET（`Promise.all`）         |
-| 法律ページ サーバー           | `getArticles` + `getLawMetadata` + `getChapters` + `getFamousArticles`（`Promise.all`） |
-| 条文ページ サーバー           | `getArticle` + `getArticles` + `getLawMetadata`（`Promise.all`）                        |
+| 場面                          | 並行呼び出し内容                                                                              |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| LikeButton トグル             | Nostalgic toggle + D1 POST（`Promise.all`）                                                   |
+| LikeButton マウント           | Nostalgic get + D1 GET（`Promise.all`）                                                       |
+| ArticleListWithEeyan マウント | `batchGetNostalgicCounts()` 経由の Nostalgic batchGet + D1 GET（`Promise.all`）               |
+| 法律ページ サーバー           | `getArticleNavList` + `getLawMetadata` + `getChapters` + `getFamousArticles`（`Promise.all`） |
+| 条文ページ サーバー           | `getArticle` + `getArticleNavList` + `getLawMetadata`（`Promise.all`）                        |
 
 ### 4.3 キャッシュ戦略まとめ
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,14 +285,14 @@ graph TB
 
 D1 からデータを取得し、HTML をレンダリングする。
 
-| コンポーネント                | D1 クエリ                                                           |
-| ----------------------------- | ------------------------------------------------------------------- |
-| `page.tsx`（トップ）          | なし（lawsMetadata.ts から静的取得）                                |
-| `[law_category]/page.tsx`     | なし（lawsMetadata.ts から静的取得）                                |
-| `[law]/page.tsx`              | `getArticles`, `getLawMetadata`, `getChapters`, `getFamousArticles` |
-| `[article]/page.tsx`          | `getArticle`, `getArticles`, `getLawMetadata`                       |
-| `api/eeyan/route.ts`          | `user_likes` テーブルの CRUD                                        |
-| `api/article-image/route.tsx` | `getArticle`, `getLawMetadata`                                      |
+| コンポーネント                | D1 クエリ                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `page.tsx`（トップ）          | なし（lawsMetadata.ts から静的取得）                                      |
+| `[law_category]/page.tsx`     | なし（lawsMetadata.ts から静的取得）                                      |
+| `[law]/page.tsx`              | `getArticleNavList`, `getLawMetadata`, `getChapters`, `getFamousArticles` |
+| `[article]/page.tsx`          | `getArticle`, `getArticleNavList`, `getLawMetadata`                       |
+| `api/eeyan/route.ts`          | `user_likes` テーブルの CRUD                                              |
+| `api/article-image/route.tsx` | `getArticle`, `getLawMetadata`                                            |
 
 ### クライアントコンポーネント（'use client'）
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -317,18 +317,20 @@ export interface LawsMetadata {
 
 `src/lib/db.ts` に定義。全て Edge Runtime で動作。
 
-| 関数                                       | SQL                                                    | 戻り値                   | 使用箇所                            |
-| ------------------------------------------ | ------------------------------------------------------ | ------------------------ | ----------------------------------- |
-| `getDB()`                                  | -                                                      | D1 バインディング        | 全関数の基盤                        |
-| `getArticles(category, lawName)`           | `SELECT ... FROM articles WHERE ... ORDER BY ...`      | `ArticleRow[]`           | 法律ページ、条文ページ              |
-| `getArticle(category, lawName, articleId)` | `SELECT * FROM articles WHERE ...`                     | `ArticleRow \| null`     | 条文ページ、OG 画像生成             |
-| `getLawMetadata(category, lawName)`        | `SELECT * FROM laws WHERE ...`                         | `LawRow \| null`         | 法律ページ、条文ページ、OG 画像生成 |
-| `getChapters(category, lawName)`           | `SELECT * FROM chapters WHERE ... ORDER BY chapter`    | `ChapterRow[]`           | 法律ページ                          |
-| `getFamousArticles(category, lawName)`     | `SELECT article, badge FROM famous_articles WHERE ...` | `Record<string, string>` | 法律ページ                          |
+| 関数                                       | SQL                                                                                                                                      | 戻り値                   | 使用箇所                            |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------- |
+| `getDB()`                                  | -                                                                                                                                        | D1 バインディング        | 全関数の基盤                        |
+| `getArticleNavList(category, lawName)`     | `SELECT article, title, title_osaka, is_deleted, substr(original_text,1,100) AS original_text_head FROM articles WHERE ... ORDER BY ...` | `ArticleNavRow[]`        | 法律ページ、条文ページ              |
+| `getArticle(category, lawName, articleId)` | `SELECT * FROM articles WHERE ...`                                                                                                       | `ArticleRow \| null`     | 条文ページ、OG 画像生成             |
+| `getLawMetadata(category, lawName)`        | `SELECT * FROM laws WHERE ...`                                                                                                           | `LawRow \| null`         | 法律ページ、条文ページ、OG 画像生成 |
+| `getChapters(category, lawName)`           | `SELECT * FROM chapters WHERE ... ORDER BY chapter`                                                                                      | `ChapterRow[]`           | 法律ページ                          |
+| `getFamousArticles(category, lawName)`     | `SELECT article, badge FROM famous_articles WHERE ...`                                                                                   | `Record<string, string>` | 法律ページ                          |
+
+`getArticleNavList()` はナビ/一覧用の軽量取得で、`original_text` をフルではなく `substr(..., 1, 100)` で先頭100文字だけ `original_text_head` として返す（条文プレビュー用途のため）。
 
 ### 条文のソート順
 
-`getArticles()` のソート:
+`getArticleNavList()` のソート:
 
 ```sql
 ORDER BY

--- a/docs/eeyan-spec.md
+++ b/docs/eeyan-spec.md
@@ -277,7 +277,7 @@ GET /api/eeyan?userId={uuid}
 
 ```sql
 SELECT ul.category, ul.law_name as lawName, ul.article, ul.created_at as createdAt,
-       a.title, a.original_text as originalText
+       a.title, substr(a.original_text, 1, 100) AS originalText
 FROM user_likes ul
 LEFT JOIN articles a ON ul.category = a.category AND ul.law_name = a.law_name AND ul.article = a.article
 WHERE ul.user_id = ?
@@ -302,7 +302,7 @@ ORDER BY ul.created_at DESC
 }
 ```
 
-`originalText` は DB上 JSON 配列として格納されているため、API側で `JSON.parse()` して最初の要素のみ文字列として返す。パース失敗時は空文字。
+`originalText` は DB上 JSON 配列として格納されているため、SQL では `substr(a.original_text, 1, 100)` で先頭100文字（head）だけを取得し、API側で `extractFirstParagraphFromHead()` により先頭段落（JSON 配列の最初の要素）を文字列として抽出して返す。プレビュー用途のためフル取得はしない。パース失敗時は空文字。
 
 **使用箇所**: `EeyanPage`（/eeyan ページ）
 

--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -48,11 +48,6 @@ export async function generateMetadata({
 
 const ARTICLES_PER_PAGE = 100;
 
-// 原文JSON断片（先頭100文字）から最初の段落を取得
-function getFirstParagraph(originalTextHead: string | null | undefined): string {
-  return extractFirstParagraphFromHead(originalTextHead);
-}
-
 // 条文番号から基本番号を抽出（1-2 → 1, 876-5 → 876）
 function getBaseArticleNumber(article: string): number {
   // suppl-1 や amend-1 は特別扱い
@@ -147,7 +142,9 @@ function toArticleData(
     href: `/law/${law_category}/${law}/${article.article}`,
     famousArticleBadge: famousArticles?.[article.article.toString()] || null,
     isDeleted: article.is_deleted === 1,
-    originalText: includeOriginalText ? getFirstParagraph(article.original_text_head) : undefined,
+    originalText: includeOriginalText
+      ? extractFirstParagraphFromHead(article.original_text_head)
+      : undefined,
   }));
 }
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -213,6 +213,14 @@ describe('navExcerptFromHead', () => {
     expect(navExcerptFromHead('["\\n\\t "]')).toBe('');
   });
 
+  it('HTMLタグを除去してから抜粋する（一覧・eeyanと整合）', () => {
+    expect(navExcerptFromHead('["<b>太字</b>条文の本文"]')).toBe('太字条文の本文');
+    // タグ除去後に12字超なら切り詰め
+    expect(navExcerptFromHead('["<span>あいうえおかきくけこさしすせそ</span>"]')).toBe(
+      'あいうえおかきくけこさし...'
+    );
+  });
+
   it('substr で切断された断片（閉じ " に届かない長い head）でも例外なく抜粋を返す', () => {
     const full = JSON.stringify([
       'とても長い第一段落のテキストがここに続いていきます、まだまだ終わりません',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -158,11 +158,12 @@ export function extractFirstParagraphFromHead(head: string | null | undefined): 
   return out;
 }
 
-/** ナビ用: 原文headから見出し無し条文のフォールバック抜粋（先頭段落をN字に切る） */
+/** ナビ用: 原文headから見出し無し条文のフォールバック抜粋（先頭段落をHTML除去・空白正規化してN字に切る） */
 export function navExcerptFromHead(head: string | null | undefined, maxLength = 12): string {
   const parsed = extractFirstParagraphFromHead(head);
   if (!parsed) return '';
-  const firstLine = parsed.replace(/\s+/g, ' ').trim();
+  // 一覧(getExcerpt)・eeyan と同様に HTML を除去して3面の抜粋整形を揃える
+  const firstLine = stripHtml(parsed).replace(/\s+/g, ' ').trim();
   return firstLine.length > maxLength ? firstLine.slice(0, maxLength) + '...' : firstLine;
 }
 


### PR DESCRIPTION
今セッションの累積変更（#56 1102根治 / #58 富豪的クエリ掃除+vitest / #60 navExcerptFromHead抽出）を `/review` で一括セルフレビューした結果の追従。独立レビューは **Approve（must 0）**。

## 変更
### docs 整合
merge 済みコードに合わせ docs を更新:
- `api.md` / `architecture.md`: 法律・条文ページの使用関数 `getArticles` → `getArticleNavList`
- `data-model.md`: `getArticles` 行を `getArticleNavList`（`substr(original_text,1,100) AS original_text_head` / `ArticleNavRow[]`）に、ソート見出しも更新
- `eeyan-spec.md`: 横断クエリを `substr(a.original_text,1,100) AS originalText` に、先頭100文字head運用の説明を追記

### レビュー指摘対応
- **nit-1**: `navExcerptFromHead` に `stripHtml` を追加し、抜粋整形を3面（一覧`getExcerpt`・eeyan・ポップアップ）で統一。現データでは見出し無し条文にHTMLは0件のため**表示は不変**（将来安全＋整合性）。テスト追加。
- **nit-2**: 一覧ページの pass-through `getFirstParagraph` を削除し `extractFirstParagraphFromHead` を直接呼び出し。

### 対応見送り（データ根拠で記録）
- **should-1**（eeyan横断クエリ LIMIT なし）: 1ユーザー最大いいね数は実測 **14**。`substr(100)` 化で1行が軽量化済みのため 1102 リスクは皆無。LIMIT は「自分のいいね一覧を黙って切る silent cap」になり害が上回るため**入れない**。

## 検証
- `npm run test`: 42/42 パス。`npm run typecheck`/`lint` グリーン。
- D1 実査: 見出し無し条文のHTML=0件 / 最大likes=14 を確認。
