### PR TITLE
法律トップ・カテゴリ一覧ページのOGP画像欠落を修正

### DIFF
--- a/src/app/law/[law_category]/[law]/page.tsx
+++ b/src/app/law/[law_category]/[law]/page.tsx
@@ -38,10 +38,13 @@ export async function generateMetadata({
       title,
       description,
       url,
+      images: ['/osaka-kenpo-logo.webp'],
     },
     twitter: {
+      card: 'summary_large_image',
       title,
       description,
+      images: ['/osaka-kenpo-logo.webp'],
     },
   };
 }

--- a/src/app/law/[law_category]/page.tsx
+++ b/src/app/law/[law_category]/page.tsx
@@ -26,10 +26,13 @@ export async function generateMetadata({
       title,
       description,
       url: `/law/${law_category}`,
+      images: ['/osaka-kenpo-logo.webp'],
     },
     twitter: {
+      card: 'summary_large_image',
       title,
       description,
+      images: ['/osaka-kenpo-logo.webp'],
     },
   };
 }


### PR DESCRIPTION
## 関連 Issue
closes #75
関連: #76（seo.tsの未使用ヘルパー一本化・フォローアップ）

## 変更内容
- `src/app/law/[law_category]/[law]/page.tsx`・`src/app/law/[law_category]/page.tsx` の `generateMetadata` に `openGraph.images`・`twitter.card`・`twitter.images` を追加
- 原因: Next.jsは子セグメントが `openGraph`/`twitter` オブジェクトを返すと親レイアウト（`layout.tsx`）のデフォルト画像がフィールド単位でマージされず消える。両ページとも `images` を指定していなかったため、法律トップ・カテゴリ一覧ページ全体でOGPカードの画像が出ない状態だった（今回追加したbuke_shohatto等に限らず既存の全法律に及ぶ）

## 検証
- ローカル `next dev` + ローカルD1シードで両ページのHTTPレスポンスを確認、`og:image`/`twitter:image` とも復活（Issue #75コメント参照）
- 条文個別ページ（`/api/article-image` の動的画像）は変更なし・回帰なしを確認
- `tsc --noEmit`・lint・build 通過

## テスト
テスト設計エージェントが「分岐ロジックのない静的リテラル追加のみ・vitestがtsxのgenerateMetadataを直接importできない設定のため新規テスト基盤構築は見合わない」と判断（スパイクで実証済み）。実機検証で代替。